### PR TITLE
feat(core,services): give native apps a device session of their own

### DIFF
--- a/packages/accounts/app.config.js
+++ b/packages/accounts/app.config.js
@@ -114,6 +114,14 @@ module.exports = {
       // module now ships inside @oxyhq/services). Reader-only: it never hosts
       // the provider.
       '@oxyhq/services/plugins/withSharedIdentityReader',
+      // Hosts the signature-protected OxyDeviceSessionProvider for the SHARED
+      // DEVICE SESSION credential — a different secret from the identity key, on
+      // its own permission and its own encrypted file. Accounts is a hub because
+      // it is inside the so.oxy.shared UID, so the file it serves is the one
+      // every UID sibling already sees. This is what lets a newly installed
+      // official app join the device's session without a QR and without ever
+      // reading the Commons private key.
+      '@oxyhq/services/plugins/withSharedDeviceSessionProvider',
       // Oxy Updates (OTA). Points expo-updates at this app's manifest endpoint on
       // the self-hosted update server in oxy-api, sets the runtimeVersion policy
       // and wires the ecosystem code-signing certificate. `expo-updates` itself

--- a/packages/commons/app.config.js
+++ b/packages/commons/app.config.js
@@ -149,6 +149,13 @@ module.exports = {
       // shared identity keypair Commons writes. Commons is the ONLY app that
       // hosts it.
       '@oxyhq/services/plugins/withSharedIdentityProvider',
+      // Also hosts the OxyDeviceSessionProvider — a SEPARATE provider, permission
+      // and encrypted file for the shared DEVICE SESSION credential. Commons is
+      // identity-bound and never publishes into that slot itself; it hosts the
+      // provider because, as a member of the so.oxy.shared UID, it serves the
+      // same file its UID siblings write, so a same-signature app outside the UID
+      // can join the device session even when Accounts is not installed.
+      '@oxyhq/services/plugins/withSharedDeviceSessionProvider',
       // Oxy Updates (OTA). Points expo-updates at this app's manifest endpoint on
       // the self-hosted update server in oxy-api, sets the runtimeVersion policy
       // and wires the ecosystem code-signing certificate. `expo-updates` itself

--- a/packages/core/src/boot/__tests__/sessionColdBoot.sharedDevice.test.ts
+++ b/packages/core/src/boot/__tests__/sessionColdBoot.sharedDevice.test.ts
@@ -1,0 +1,325 @@
+/**
+ * `shared-device-adopt` — the cold-boot lane that lets a freshly installed
+ * official app join the device's EXISTING session with no QR and, crucially,
+ * with no access to the Commons private identity key.
+ *
+ * What is pinned here:
+ *   - a fresh install adopts the shared credential and mints;
+ *   - an app that already has a credential is never moved (upgrade order cannot
+ *     sign anyone out, in either direction);
+ *   - an UNREADABLE shared slot is not a fresh device — the lane skips and the
+ *     legacy identity-key lane still gets its turn;
+ *   - a failed adoption leaves the local store byte-for-byte as it was;
+ *   - `sessionMode: 'identity'` never runs the lane at all;
+ *   - web never runs it.
+ */
+import type { OxyServices } from '../../OxyServices';
+import type { DeviceTokenMintResponse } from '@oxyhq/contracts';
+import type { SessionLoginResponse } from '../../models/session';
+import { runSessionColdBoot } from '../sessionColdBoot';
+import type { DeviceSecretMintOutcome } from '../../session/refresh';
+import { createMemoryAuthStateStore, type PersistedAuthState } from '../../session/authStateStore';
+import type {
+  SharedDeviceCredentialRead,
+  SharedDeviceCredentialStore,
+} from '../../session/sharedDeviceCredential';
+import { createMemoryIdentityPinStore } from '../../session/identityPin';
+import type { IdentityBinding } from '../../session/identitySession';
+
+const WEB = { isWeb: true, isNative: false };
+const NATIVE = { isWeb: false, isNative: true };
+
+const SHARED_CRED = { deviceId: 'dev-shared', deviceSecret: 'ds-shared' };
+const OWN_CRED = { deviceId: 'dev-own', deviceSecret: 'ds-own' };
+
+const MINT: DeviceTokenMintResponse = {
+  accessToken: 'access-joined',
+  expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+  nextDeviceSecret: SHARED_CRED.deviceSecret,
+  state: {
+    deviceId: SHARED_CRED.deviceId,
+    accounts: [{ accountId: 'user-shared', sessionId: 'sess-shared', authuser: 0 }],
+    activeAccountId: 'user-shared',
+    revision: 9,
+    updatedAt: 1_700_000_000_000,
+  },
+};
+
+/** A real device-secret mint single-flight matching HttpService's. */
+function makeMintSingleFlight(): (mint: () => Promise<DeviceSecretMintOutcome>) => Promise<DeviceSecretMintOutcome> {
+  let inFlight: Promise<DeviceSecretMintOutcome> | null = null;
+  return (mint) => {
+    if (!inFlight) {
+      inFlight = mint().finally(() => {
+        inFlight = null;
+      });
+    }
+    return inFlight;
+  };
+}
+
+/** A 401 error shaped like `HttpService`/`handleError` output for the given body. */
+function mint401(body: string): Error & { status: number } {
+  return Object.assign(new Error(body), { status: 401 });
+}
+
+function makeOxy(overrides: {
+  mintFromDeviceSecret?: OxyServices['mintFromDeviceSecret'];
+  signInWithSharedIdentity?: OxyServices['signInWithSharedIdentity'];
+} = {}) {
+  const setTokens = jest.fn();
+  const mintFromDeviceSecret = jest.fn(
+    overrides.mintFromDeviceSecret ?? (async () => MINT),
+  ) as unknown as OxyServices['mintFromDeviceSecret'];
+  const signInWithSharedIdentity = jest.fn(
+    overrides.signInWithSharedIdentity ?? (async () => null),
+  ) as unknown as OxyServices['signInWithSharedIdentity'];
+  const oxy = {
+    getBaseURL: () => 'https://api.oxy.so',
+    setTokens,
+    mintFromDeviceSecret,
+    signInWithSharedIdentity,
+    httpService: { runSingleFlightDeviceSecretMint: makeMintSingleFlight() },
+  } as unknown as OxyServices;
+  return { oxy, setTokens, mintFromDeviceSecret, signInWithSharedIdentity };
+}
+
+function makeSharedSlot(initial: SharedDeviceCredentialRead) {
+  let current = initial;
+  const read = jest.fn(async () => current);
+  const publish = jest.fn(async () => true);
+  const clear = jest.fn(async () => {
+    current = { state: 'absent' };
+  });
+  const store: SharedDeviceCredentialStore = { read, publish, clear };
+  return { store, read, publish, clear };
+}
+
+/** An identity binding that resolves a local key, for the identity-mode case. */
+function makeIdentityBinding(): IdentityBinding {
+  return {
+    pinStore: createMemoryIdentityPinStore(),
+    getPublicKey: async () => 'pub-identity',
+    signMessage: async () => 'sig-identity',
+  };
+}
+
+describe('cold boot — shared-device-adopt', () => {
+  test('a fresh install adopts the shared credential and mints a session', async () => {
+    const store = createMemoryAuthStateStore();
+    const slot = makeSharedSlot({ state: 'present', credential: SHARED_CRED });
+    const { oxy, mintFromDeviceSecret, setTokens } = makeOxy();
+
+    const outcome = await runSessionColdBoot({
+      oxy,
+      store,
+      platform: NATIVE,
+      sharedDeviceCredential: slot.store,
+    });
+
+    expect(outcome).toMatchObject({ kind: 'session', via: 'shared-device-adopt' });
+    expect(mintFromDeviceSecret).toHaveBeenCalledWith(SHARED_CRED.deviceId, SHARED_CRED.deviceSecret);
+    expect(setTokens).toHaveBeenCalledWith(MINT.accessToken);
+    // The adopted credential is now this app's own, so the next boot takes the
+    // faster `device-secret-mint` lane.
+    expect(await store.load()).toMatchObject({
+      deviceId: SHARED_CRED.deviceId,
+      deviceSecret: SHARED_CRED.deviceSecret,
+      sessionId: 'sess-shared',
+      userId: 'user-shared',
+    });
+  });
+
+  test('the identity key is never touched when the shared credential works', async () => {
+    // The whole point of the separation: an ordinary app joins the device session
+    // without ever asking for the key that signs identity approvals.
+    const slot = makeSharedSlot({ state: 'present', credential: SHARED_CRED });
+    const { oxy, signInWithSharedIdentity } = makeOxy();
+
+    await runSessionColdBoot({
+      oxy,
+      store: createMemoryAuthStateStore(),
+      platform: NATIVE,
+      sharedDeviceCredential: slot.store,
+    });
+
+    expect(signInWithSharedIdentity).not.toHaveBeenCalled();
+  });
+
+  test('an app that already holds its own credential is not moved onto the shared one', async () => {
+    // Upgrade order must not sign anyone out. This app's own session wins.
+    const store = createMemoryAuthStateStore();
+    await store.save({ sessionId: 'sess-own', userId: 'user-own', ...OWN_CRED });
+    const slot = makeSharedSlot({ state: 'present', credential: SHARED_CRED });
+    const { oxy, mintFromDeviceSecret } = makeOxy({
+      mintFromDeviceSecret: (async () => ({
+        ...MINT,
+        nextDeviceSecret: OWN_CRED.deviceSecret,
+        state: { ...MINT.state, deviceId: OWN_CRED.deviceId },
+      })) as unknown as OxyServices['mintFromDeviceSecret'],
+    });
+
+    const outcome = await runSessionColdBoot({
+      oxy,
+      store,
+      platform: NATIVE,
+      sharedDeviceCredential: slot.store,
+    });
+
+    expect(outcome).toMatchObject({ kind: 'session', via: 'device-secret-mint' });
+    expect(mintFromDeviceSecret).toHaveBeenCalledWith(OWN_CRED.deviceId, OWN_CRED.deviceSecret);
+    expect(mintFromDeviceSecret).not.toHaveBeenCalledWith(SHARED_CRED.deviceId, SHARED_CRED.deviceSecret);
+    expect(await store.load()).toMatchObject({ deviceId: OWN_CRED.deviceId });
+  });
+
+  test('an UNREADABLE shared slot is not treated as a fresh device', async () => {
+    // A locked keystore must never authorise anything. The lane skips, the store
+    // is untouched, and the legacy identity lane still gets its turn — which is
+    // what keeps a momentarily-locked device from silently onboarding again.
+    const store = createMemoryAuthStateStore();
+    const slot = makeSharedSlot({ state: 'unavailable', cause: new Error('keystore locked') });
+    const sharedKeySession = {
+      sessionId: 'sess-legacy',
+      user: { id: 'user-legacy' },
+      accessToken: 'access-legacy',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      deviceId: 'dev-legacy',
+      deviceSecret: 'ds-legacy',
+    } as unknown as SessionLoginResponse;
+    const { oxy, signInWithSharedIdentity } = makeOxy({
+      signInWithSharedIdentity: (async () => sharedKeySession) as unknown as OxyServices['signInWithSharedIdentity'],
+    });
+
+    const outcome = await runSessionColdBoot({
+      oxy,
+      store,
+      platform: NATIVE,
+      sharedDeviceCredential: slot.store,
+    });
+
+    expect(slot.publish).not.toHaveBeenCalled();
+    expect(slot.clear).not.toHaveBeenCalled();
+    expect(signInWithSharedIdentity).toHaveBeenCalled();
+    expect(outcome).toMatchObject({ kind: 'session', via: 'shared-key-signin' });
+  });
+
+  test('an empty shared slot falls through to the legacy identity lane', async () => {
+    const slot = makeSharedSlot({ state: 'absent' });
+    const { oxy, signInWithSharedIdentity } = makeOxy();
+
+    const outcome = await runSessionColdBoot({
+      oxy,
+      store: createMemoryAuthStateStore(),
+      platform: NATIVE,
+      sharedDeviceCredential: slot.store,
+    });
+
+    expect(signInWithSharedIdentity).toHaveBeenCalled();
+    expect(outcome).toEqual({ kind: 'unauthenticated' });
+  });
+
+  test('a rejected shared credential is reverted locally and cleared from the slot', async () => {
+    // `invalid_device_secret` is the one positive proof that the exact shared
+    // bytes are dead. Reverting keeps this app where it was; clearing the slot is
+    // what stops a dead credential from blocking every future install.
+    const store = createMemoryAuthStateStore();
+    const before: PersistedAuthState = { sessionId: 'sess-stale', userId: 'user-stale' };
+    await store.save(before);
+    const slot = makeSharedSlot({ state: 'present', credential: SHARED_CRED });
+    const { oxy } = makeOxy({
+      mintFromDeviceSecret: (async () => {
+        throw mint401('invalid_device_secret');
+      }) as unknown as OxyServices['mintFromDeviceSecret'],
+    });
+
+    const outcome = await runSessionColdBoot({
+      oxy,
+      store,
+      platform: NATIVE,
+      sharedDeviceCredential: slot.store,
+    });
+
+    expect(outcome).toEqual({ kind: 'unauthenticated' });
+    expect(slot.clear).toHaveBeenCalledTimes(1);
+    expect(await store.load()).toEqual(before);
+  });
+
+  test('a transient mint failure reverts without clearing the shared slot', async () => {
+    // A network blip says nothing about the credential. Wiping the device-wide
+    // join point on an ambiguous failure is the deploy-window bug, one layer up.
+    const store = createMemoryAuthStateStore();
+    const slot = makeSharedSlot({ state: 'present', credential: SHARED_CRED });
+    const { oxy } = makeOxy({
+      mintFromDeviceSecret: (async () => {
+        throw new Error('network down');
+      }) as unknown as OxyServices['mintFromDeviceSecret'],
+    });
+
+    await runSessionColdBoot({ oxy, store, platform: NATIVE, sharedDeviceCredential: slot.store });
+
+    expect(slot.clear).not.toHaveBeenCalled();
+    expect(await store.load()).toBeNull();
+  });
+
+  test('the lane does not run on web', async () => {
+    const slot = makeSharedSlot({ state: 'present', credential: SHARED_CRED });
+    const { oxy, mintFromDeviceSecret } = makeOxy();
+
+    const outcome = await runSessionColdBoot({
+      oxy,
+      store: createMemoryAuthStateStore(),
+      platform: WEB,
+      sharedDeviceCredential: slot.store,
+    });
+
+    expect(slot.read).not.toHaveBeenCalled();
+    expect(mintFromDeviceSecret).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ kind: 'unauthenticated' });
+  });
+
+  test('the lane does not run when the device reports itself offline', async () => {
+    const slot = makeSharedSlot({ state: 'present', credential: SHARED_CRED });
+    const { oxy } = makeOxy();
+
+    await runSessionColdBoot({
+      oxy,
+      store: createMemoryAuthStateStore(),
+      platform: NATIVE,
+      isOffline: () => true,
+      sharedDeviceCredential: slot.store,
+    });
+
+    expect(slot.read).not.toHaveBeenCalled();
+  });
+
+  test('identity mode never reads the shared slot', async () => {
+    // The slot belongs to whichever principal signed in on this device. An
+    // identity-bound client resolves its session from the local key alone —
+    // adopting a device credential is the drift that mode exists to prevent.
+    const slot = makeSharedSlot({ state: 'present', credential: SHARED_CRED });
+    const { oxy } = makeOxy();
+
+    await runSessionColdBoot({
+      oxy,
+      store: createMemoryAuthStateStore(),
+      platform: NATIVE,
+      sessionMode: 'identity',
+      identity: makeIdentityBinding(),
+      sharedDeviceCredential: slot.store,
+    });
+
+    expect(slot.read).not.toHaveBeenCalled();
+    expect(slot.publish).not.toHaveBeenCalled();
+  });
+
+  test('omitting the slot leaves the boot chain exactly as it was', async () => {
+    const slot = makeSharedSlot({ state: 'present', credential: SHARED_CRED });
+    const { oxy, signInWithSharedIdentity } = makeOxy();
+
+    const outcome = await runSessionColdBoot({ oxy, store: createMemoryAuthStateStore(), platform: NATIVE });
+
+    expect(slot.read).not.toHaveBeenCalled();
+    expect(signInWithSharedIdentity).toHaveBeenCalled();
+    expect(outcome).toEqual({ kind: 'unauthenticated' });
+  });
+});

--- a/packages/core/src/boot/sessionColdBoot.ts
+++ b/packages/core/src/boot/sessionColdBoot.ts
@@ -15,10 +15,17 @@
  *      origin persisted a `deviceId` + `deviceSecret`, mint a short access token
  *      with a single bearer-less POST to `/session/device/token` (no cookie, no
  *      navigation) and rotate the secret in-use.
- *   3. `shared-key-signin` (native, ACCOUNT mode) — re-mint from the
- *      shared-keychain identity — OR `identity-key-signin` (IDENTITY mode) —
- *      re-mint from THIS device's primary identity key.
- *   4. Signed out.
+ *   3. `shared-device-adopt` (native, ACCOUNT mode) — this app has no credential
+ *      of its own but a sibling official app already put one in the shared native
+ *      slot: adopt it and mint. This is how a newly installed official app joins
+ *      the device's existing session WITHOUT another QR and without ever touching
+ *      the Commons private key.
+ *   4. `shared-key-signin` (native, ACCOUNT mode) — the legacy lane: re-mint by
+ *      signing with the shared-keychain IDENTITY key. Retained as a recovery /
+ *      compatibility path for devices whose apps have not yet published a shared
+ *      device credential — OR `identity-key-signin` (IDENTITY mode) — re-mint
+ *      from THIS device's primary identity key.
+ *   5. Signed out.
  *
  * Two session modes (see {@link RunSessionColdBootOptions.sessionMode}):
  *   - `account` (default) — the device's ACTIVE account owns the session. Every
@@ -42,8 +49,12 @@ import {
   type IdentityBinding,
 } from '../session/identitySession';
 import type { IdentityPin } from '../session/identityPin';
+import {
+  decideSharedDeviceJoin,
+  type SharedDeviceCredentialStore,
+} from '../session/sharedDeviceCredential';
 import type { OxyServices } from '../OxyServices';
-import type { AuthStateStore } from '../session/authStateStore';
+import type { AuthStateStore, PersistedAuthState } from '../session/authStateStore';
 
 /**
  * Who owns the session this boot resolves.
@@ -116,6 +127,18 @@ export interface RunSessionColdBootOptions {
    * `sessionMode: 'identity'`. Ignored in `'account'` mode.
    */
   identity?: IdentityBinding;
+  /**
+   * The cross-app native slot holding this device's shared DeviceSession
+   * credential, enabling the `shared-device-adopt` lane. Supplied by
+   * `@oxyhq/services` on native; absent on web, where each origin is its own
+   * device by design.
+   *
+   * IGNORED in `sessionMode: 'identity'`. The shared slot belongs to whichever
+   * principal signed in on this device; an identity-bound client must resolve
+   * its session from the local key alone, and adopting a device credential is
+   * exactly the drift that mode exists to prevent.
+   */
+  sharedDeviceCredential?: SharedDeviceCredentialStore;
 }
 
 /**
@@ -342,10 +365,111 @@ export async function runSessionColdBoot(
         };
       },
     });
-  } else {
-    // 3. shared-key-signin (native) — re-mint from the shared identity. Native
-    //    AND online: it is a network step (challenge + verify round-trips), so it
-    //    is gated by the same offline hint as the mint lane. `{ retry: false }`
+  } else if (opts.sharedDeviceCredential) {
+    // 3. shared-device-adopt (native, ACCOUNT mode) — join the device's existing
+    //    session through the shared native credential slot.
+    //
+    //    This is the lane that separates identity from session transport. What it
+    //    reads is an ordinary, individually revocable `deviceId` + `deviceSecret`
+    //    put there by a sibling official app — never the Commons private key. It
+    //    is what lets a freshly installed official app land signed in with no QR,
+    //    and it is why an ordinary app never needs identity-key access at all.
+    //
+    //    `decideSharedDeviceJoin` gates it: an app that already holds its own
+    //    credential is never moved, and an UNREADABLE slot is never mistaken for
+    //    an empty one. The lane therefore cannot sign anyone out, in either
+    //    upgrade order.
+    const sharedSlot = opts.sharedDeviceCredential;
+    steps.push({
+      id: 'shared-device-adopt',
+      // The adoption itself is local, but it is only worth committing alongside
+      // a mint that proves the credential — so the whole lane is online-gated
+      // like every other network step.
+      enabled: () => isNative && !isOffline(),
+      run: async () => {
+        const before = await store.load();
+        const decision = decideSharedDeviceJoin(before, await sharedSlot.read());
+        if (decision.action === 'skip') {
+          logger.debug(
+            `shared device credential not adopted (${decision.reason})`,
+            { component: 'sessionColdBoot', method: 'shared-device-adopt' },
+          );
+          return { kind: 'skip' };
+        }
+
+        // Restore the store to exactly what it held before this lane touched it.
+        // A credential we adopted and could not prove must not be left behind for
+        // the next boot's mint lane to keep retrying.
+        const revert = async (): Promise<void> => {
+          if (before) {
+            await store.save(before);
+          } else {
+            await store.clear();
+          }
+        };
+
+        const adopted: PersistedAuthState = {
+          // The mint fills both in from the device's live state; carrying the
+          // previous session's ids into a different device session would be a
+          // lie for however long the mint takes.
+          sessionId: '',
+          userId: '',
+          deviceId: decision.credential.deviceId,
+          deviceSecret: decision.credential.deviceSecret,
+        };
+        if (!(await store.save(adopted))) {
+          logger.error(
+            'adopted the shared device credential but it could not be durably persisted — reverting',
+            undefined,
+            { component: 'sessionColdBoot', method: 'shared-device-adopt' },
+          );
+          await revert();
+          return { kind: 'skip' };
+        }
+
+        const result = await refreshDeviceSecretArm({ oxy, store, pin: null });
+        if (result.status === 'ok') {
+          return {
+            kind: 'session',
+            session: {
+              sessionId: result.sessionId,
+              userId: result.userId,
+              accessToken: result.token,
+            },
+          };
+        }
+
+        if (result.status === 'invalid-secret') {
+          // The one place we hold POSITIVE proof that the exact bytes in the
+          // shared slot are dead — the server rejected them by name. Clearing it
+          // signs nobody out (a credential the server does not recognise cannot
+          // be minting for anyone) and it is what stops a dead credential from
+          // blocking every future install: a stale slot owned by a different
+          // `deviceId` is otherwise never overwritten, by design.
+          await sharedSlot.clear();
+        } else if (result.status === 'no-session') {
+          signedOutReason = 'no_session';
+        }
+        await revert();
+        return { kind: 'skip' };
+      },
+    });
+  }
+
+  if (identityBinding === null) {
+    // 4. shared-key-signin (native) — the RECOVERY / COMPATIBILITY lane: sign a
+    //    challenge with the shared-keychain IDENTITY key to re-mint a session.
+    //
+    //    It runs LAST on purpose. Using the self-custody key to obtain an ordinary
+    //    session is the over-sharing #937 sets out to end, so it is now reachable
+    //    only on a device where no sibling app has published a shared device
+    //    credential yet — an install that predates this lane, or one where the
+    //    shared slot is unreadable. Its own `store.save` below feeds the shared
+    //    slot through the mirroring store, so the FIRST boot that takes this lane
+    //    is also the last one that needs to: every later app joins by credential.
+    //
+    //    Native AND online: it is a network step (challenge + verify round-trips),
+    //    so it is gated by the same offline hint as the mint lane. `{ retry: false }`
     //    keeps the two round-trips as single attempts — the refresh scheduler /
     //    401 lane own later retries — so this step cannot multiply boot latency.
     steps.push({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -774,6 +774,30 @@ export type {
     NativeKeyValueStorage,
 } from './session/authStateStore';
 
+// The shared NATIVE DeviceSession credential — how several official apps on one
+// device end up on ONE `DeviceSession` and therefore one active context. It is an
+// ordinary rotatable/revocable `deviceId` + `deviceSecret`, deliberately NOT the
+// Commons private identity key: an app that only needs a session must never be
+// handed the key that signs identity approvals.
+export {
+    createSharedMirroringAuthStateStore,
+    decideSharedDeviceJoin,
+    decideSharedDevicePublish,
+    normalizeSharedDeviceSessionRead,
+    publishProvenDeviceCredential,
+    readLocalDeviceCredential,
+} from './session/sharedDeviceCredential';
+export type {
+    SharedDeviceCredential,
+    SharedDeviceCredentialRead,
+    SharedDeviceCredentialStore,
+    SharedDeviceJoinDecision,
+    SharedDeviceJoinSkipReason,
+    SharedDevicePublishDecision,
+    SharedDevicePublishOutcome,
+    SharedDevicePublishSkipReason,
+} from './session/sharedDeviceCredential';
+
 // Identity-bound sessions (the identity vault). The pin is the durable
 // `{publicKey, accountId}` binding between this device's PRIMARY identity key
 // and the account it authenticates as; it is what keeps such a client from

--- a/packages/core/src/session/__tests__/sharedDeviceCredential.test.ts
+++ b/packages/core/src/session/__tests__/sharedDeviceCredential.test.ts
@@ -1,0 +1,300 @@
+/**
+ * The shared native DeviceSession credential — the decision rules that separate
+ * "this device already has a session" from "this device could not be read".
+ *
+ * Every case here is written against the one failure this module exists to make
+ * unreachable: a secure store that is LOCKED or BROKEN looking like a secure
+ * store that is EMPTY. The empty answer authorises a write into the slot; the
+ * failed answer must authorise nothing. Several assertions below are the only
+ * thing standing between that misreading and a live shared session being
+ * overwritten, so they are written to fail loudly rather than shrink quietly.
+ */
+import { createMemoryAuthStateStore, type AuthStateStore, type PersistedAuthState } from '../authStateStore';
+import {
+  createSharedMirroringAuthStateStore,
+  decideSharedDeviceJoin,
+  decideSharedDevicePublish,
+  normalizeSharedDeviceSessionRead,
+  publishProvenDeviceCredential,
+  readLocalDeviceCredential,
+  type SharedDeviceCredential,
+  type SharedDeviceCredentialRead,
+  type SharedDeviceCredentialStore,
+} from '../sharedDeviceCredential';
+
+const CRED: SharedDeviceCredential = { deviceId: 'dev-shared', deviceSecret: 'ds-shared' };
+const OTHER: SharedDeviceCredential = { deviceId: 'dev-other', deviceSecret: 'ds-other' };
+
+const PRESENT: SharedDeviceCredentialRead = { state: 'present', credential: CRED };
+const ABSENT: SharedDeviceCredentialRead = { state: 'absent' };
+const UNAVAILABLE: SharedDeviceCredentialRead = { state: 'unavailable', cause: new Error('keychain locked') };
+const UNSUPPORTED: SharedDeviceCredentialRead = { state: 'unsupported' };
+
+/** Every read state, so a new one cannot be added without deciding what it means. */
+const ALL_READS: SharedDeviceCredentialRead[] = [PRESENT, ABSENT, UNAVAILABLE, UNSUPPORTED];
+
+function localWith(credential: SharedDeviceCredential | null): PersistedAuthState {
+  return {
+    sessionId: 'sess-local',
+    userId: 'user-local',
+    ...(credential ? { deviceId: credential.deviceId, deviceSecret: credential.deviceSecret } : {}),
+  };
+}
+
+/** An in-memory {@link SharedDeviceCredentialStore} with scripted read behaviour. */
+function makeSharedStore(initial: SharedDeviceCredentialRead) {
+  let current = initial;
+  const publish = jest.fn(async (credential: SharedDeviceCredential) => {
+    current = { state: 'present', credential };
+    return true;
+  });
+  const clear = jest.fn(async () => {
+    current = { state: 'absent' };
+  });
+  const store: SharedDeviceCredentialStore = {
+    read: async () => current,
+    publish,
+    clear,
+  };
+  return { store, publish, clear, peek: () => current };
+}
+
+describe('readLocalDeviceCredential', () => {
+  test('requires BOTH halves of the mint credential', () => {
+    expect(readLocalDeviceCredential(null)).toBeNull();
+    expect(readLocalDeviceCredential({ sessionId: 's', userId: 'u' })).toBeNull();
+    expect(readLocalDeviceCredential({ sessionId: 's', userId: 'u', deviceId: 'd' })).toBeNull();
+    expect(readLocalDeviceCredential({ sessionId: 's', userId: 'u', deviceSecret: 'x' })).toBeNull();
+    expect(readLocalDeviceCredential(localWith(CRED))).toEqual(CRED);
+  });
+});
+
+describe('normalizeSharedDeviceSessionRead', () => {
+  test('narrows a well-formed present payload', () => {
+    expect(
+      normalizeSharedDeviceSessionRead({ status: 'present', deviceId: 'dev-x', deviceSecret: 'ds-x' }),
+    ).toEqual({ state: 'present', credential: { deviceId: 'dev-x', deviceSecret: 'ds-x' } });
+  });
+
+  test('narrows an explicit absent payload', () => {
+    expect(normalizeSharedDeviceSessionRead({ status: 'absent' })).toEqual({ state: 'absent' });
+  });
+
+  test.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'absent'],
+    ['a number', 0],
+    ['an empty object', {}],
+    ['an unknown status', { status: 'maybe' }],
+    ['present with no deviceId', { status: 'present', deviceSecret: 'ds-x' }],
+    ['present with no deviceSecret', { status: 'present', deviceId: 'dev-x' }],
+    ['present with an empty deviceSecret', { status: 'present', deviceId: 'dev-x', deviceSecret: '' }],
+    ['present with a non-string deviceId', { status: 'present', deviceId: 7, deviceSecret: 'ds-x' }],
+    ['an explicit unavailable', { status: 'unavailable', reason: 'keystore' }],
+  ])('reports %s as unavailable, never absent', (_label, raw) => {
+    const read = normalizeSharedDeviceSessionRead(raw);
+    // `unavailable` and `absent` are the pair that must never be confused: the
+    // second one authorises a write into the slot.
+    expect(read.state).toBe('unavailable');
+  });
+});
+
+describe('decideSharedDeviceJoin', () => {
+  test('adopts when the slot holds a credential and this app has none', () => {
+    expect(decideSharedDeviceJoin(localWith(null), PRESENT)).toEqual({ action: 'adopt', credential: CRED });
+    expect(decideSharedDeviceJoin(null, PRESENT)).toEqual({ action: 'adopt', credential: CRED });
+  });
+
+  test('NEVER adopts when the slot could not be read', () => {
+    // The keystore-unavailable case. Adopting nothing is right; the danger is a
+    // caller downstream reading this as "fresh device".
+    expect(decideSharedDeviceJoin(localWith(null), UNAVAILABLE)).toEqual({
+      action: 'skip',
+      reason: 'shared-unreadable',
+    });
+  });
+
+  test('reports an unsupported slot distinctly from an unreadable one', () => {
+    // Same behaviour, different diagnosis: no shared transport in this build is
+    // normal, an unreadable one is not.
+    expect(decideSharedDeviceJoin(localWith(null), UNSUPPORTED)).toEqual({
+      action: 'skip',
+      reason: 'shared-unsupported',
+    });
+  });
+
+  test('skips an empty slot', () => {
+    expect(decideSharedDeviceJoin(localWith(null), ABSENT)).toEqual({ action: 'skip', reason: 'shared-empty' });
+  });
+
+  test('never moves an app that already holds its own credential — in ANY slot state', () => {
+    // "No user is signed out merely because one app updates first" holds by
+    // construction: whatever the slot says, an app with a working credential of
+    // its own is left exactly where it is. Including when the slot holds a
+    // DIFFERENT device session.
+    for (const read of ALL_READS) {
+      expect(decideSharedDeviceJoin(localWith(OTHER), read)).toEqual({
+        action: 'skip',
+        reason: 'local-credential-present',
+      });
+    }
+    expect(ALL_READS).toHaveLength(4);
+  });
+});
+
+describe('decideSharedDevicePublish', () => {
+  test('seeds an empty slot with a proven credential', () => {
+    expect(decideSharedDevicePublish(CRED, ABSENT)).toEqual({ action: 'publish' });
+  });
+
+  test('NEVER writes over a slot it could not read', () => {
+    // The destructive direction. An unreadable slot may hold another principal's
+    // live session; writing on the strength of a failed read is how it is lost.
+    expect(decideSharedDevicePublish(CRED, UNAVAILABLE)).toEqual({
+      action: 'skip',
+      reason: 'shared-unreadable',
+    });
+  });
+
+  test('does not write when there is no slot at all', () => {
+    expect(decideSharedDevicePublish(CRED, UNSUPPORTED)).toEqual({
+      action: 'skip',
+      reason: 'shared-unsupported',
+    });
+  });
+
+  test('refreshes the secret for the SAME device session', () => {
+    const rotated = { deviceId: CRED.deviceId, deviceSecret: 'ds-rotated' };
+    expect(decideSharedDevicePublish(rotated, PRESENT)).toEqual({ action: 'publish' });
+  });
+
+  test('is a no-op when the slot already holds exactly this credential', () => {
+    expect(decideSharedDevicePublish(CRED, PRESENT)).toEqual({ action: 'skip', reason: 'already-current' });
+  });
+
+  test('leaves a slot owned by a DIFFERENT device session alone', () => {
+    // Overwriting would silently migrate every other app on this device onto our
+    // session at their next cold boot. That is a user-visible change of identity,
+    // not something a background persist decides.
+    expect(decideSharedDevicePublish(OTHER, PRESENT)).toEqual({
+      action: 'skip',
+      reason: 'owned-by-another-device',
+    });
+  });
+});
+
+describe('publishProvenDeviceCredential', () => {
+  test('writes into an empty slot', async () => {
+    const shared = makeSharedStore(ABSENT);
+    await expect(publishProvenDeviceCredential({ shared: shared.store, credential: CRED })).resolves.toEqual({
+      status: 'published',
+    });
+    expect(shared.publish).toHaveBeenCalledWith(CRED);
+    expect(shared.peek()).toEqual(PRESENT);
+  });
+
+  test('does not call publish at all when the slot is unreadable', async () => {
+    const shared = makeSharedStore(UNAVAILABLE);
+    await expect(publishProvenDeviceCredential({ shared: shared.store, credential: CRED })).resolves.toEqual({
+      status: 'skipped',
+      reason: 'shared-unreadable',
+    });
+    expect(shared.publish).not.toHaveBeenCalled();
+  });
+
+  test('reports an unverified write as a failure rather than a success', async () => {
+    const shared: SharedDeviceCredentialStore = {
+      read: async () => ABSENT,
+      // The contract is read-back-verified; a store that could not confirm the
+      // bytes landed must say so, or a fresh install joins with a phantom.
+      publish: async () => false,
+      clear: async () => undefined,
+    };
+    await expect(publishProvenDeviceCredential({ shared, credential: CRED })).resolves.toEqual({
+      status: 'publish-failed',
+    });
+  });
+});
+
+describe('createSharedMirroringAuthStateStore', () => {
+  function harness(initial: SharedDeviceCredentialRead = ABSENT) {
+    const local = createMemoryAuthStateStore();
+    const shared = makeSharedStore(initial);
+    return { local, shared, store: createSharedMirroringAuthStateStore({ local, shared: shared.store }) };
+  }
+
+  test('mirrors a saved credential into the shared slot', async () => {
+    const h = harness();
+    await expect(h.store.save(localWith(CRED))).resolves.toBe(true);
+    expect(h.shared.publish).toHaveBeenCalledWith(CRED);
+    expect(await h.local.load()).toEqual(localWith(CRED));
+  });
+
+  test('does not re-write the slot when the credential has not changed', async () => {
+    const h = harness();
+    await h.store.save(localWith(CRED));
+    await h.store.save({ ...localWith(CRED), accessToken: 'warm', expiresAt: 'later' });
+    await h.store.save({ ...localWith(CRED), accessToken: 'warmer', expiresAt: 'later-still' });
+    expect(h.shared.publish).toHaveBeenCalledTimes(1);
+  });
+
+  test('mirrors again once the credential really changes', async () => {
+    const h = harness();
+    await h.store.save(localWith(CRED));
+    await h.store.save(localWith({ deviceId: CRED.deviceId, deviceSecret: 'ds-rotated' }));
+    expect(h.shared.publish).toHaveBeenCalledTimes(2);
+  });
+
+  test('saves nothing to the slot when the state carries no credential', async () => {
+    const h = harness();
+    await h.store.save({ sessionId: 's', userId: 'u' });
+    expect(h.shared.publish).not.toHaveBeenCalled();
+  });
+
+  test('reports the LOCAL durability verdict, not the mirror outcome', async () => {
+    // The caller's contract is about the durable local write — a lane persisting
+    // a rotated secret treats `false` as fatal. A best-effort mirror must never
+    // be able to flip that answer in either direction.
+    const failingLocal: AuthStateStore = {
+      load: async () => null,
+      save: async () => false,
+      clear: async () => undefined,
+    };
+    const shared = makeSharedStore(ABSENT);
+    const store = createSharedMirroringAuthStateStore({ local: failingLocal, shared: shared.store });
+    await expect(store.save(localWith(CRED))).resolves.toBe(false);
+    expect(shared.publish).toHaveBeenCalledWith(CRED);
+  });
+
+  test('a throwing shared store cannot fail a successful local write', async () => {
+    const shared: SharedDeviceCredentialStore = {
+      read: async () => {
+        throw new Error('binder died');
+      },
+      publish: async () => true,
+      clear: async () => undefined,
+    };
+    const store = createSharedMirroringAuthStateStore({ local: createMemoryAuthStateStore(), shared });
+    await expect(store.save(localWith(CRED))).resolves.toBe(true);
+  });
+
+  test('signing out of THIS app does not clear the device-wide slot', async () => {
+    // Other apps may still be signed in on that credential, and once the server
+    // session is gone the credential mints `no_active_session` for everyone
+    // anyway. This app's sign-out is not authority over the join point.
+    const h = harness();
+    await h.store.save(localWith(CRED));
+    await h.store.clear();
+    expect(h.shared.clear).not.toHaveBeenCalled();
+    expect(h.shared.peek()).toEqual(PRESENT);
+    expect(await h.local.load()).toBeNull();
+  });
+
+  test('load is a pass-through and never adopts', async () => {
+    // Adoption is an explicit cold-boot step. A storage primitive must not be
+    // able to change who the app is signed in as.
+    const h = harness(PRESENT);
+    expect(await h.store.load()).toBeNull();
+  });
+});

--- a/packages/core/src/session/sharedDeviceCredential.ts
+++ b/packages/core/src/session/sharedDeviceCredential.ts
@@ -1,0 +1,349 @@
+/**
+ * The shared native DeviceSession credential — one device, one session, many apps.
+ *
+ * ## What this is, and what it deliberately is NOT
+ *
+ * Two different secrets can make a native Oxy app boot signed in, and conflating
+ * them is the bug this module exists to end:
+ *
+ *   Commons private identity key   → identity and signed approval ONLY. It is
+ *                                    self-custody, irreplaceable, and must never
+ *                                    become the general app session transport.
+ *   Shared DeviceSession credential → THIS module. An ordinary `deviceId` +
+ *                                    `deviceSecret` pair that restores ordinary
+ *                                    official apps, follows the device's active
+ *                                    context, and is individually rotatable and
+ *                                    revocable server-side.
+ *
+ * An ordinary app needs the second one. Handing it the first — which is what the
+ * `shared-key-signin` lane does today — gives every sibling app the ability to
+ * sign as the user's cryptographic identity to obtain something as mundane as a
+ * session. That lane stays as a recovery/compatibility path; this one supersedes
+ * it for the ordinary case.
+ *
+ * ## Why sharing one credential is safe against the server
+ *
+ * `POST /session/device/token` does NOT rotate: the response echoes the presented
+ * secret back as `nextDeviceSecret` precisely so several first-party apps sharing
+ * one `DeviceSession` can refresh concurrently without invalidating one another.
+ * So N apps holding one credential is a supported server state, not a race — and
+ * because they then share ONE `DeviceSession`, they automatically share its
+ * `activeContextId` and its token-free `session_state` broadcasts.
+ *
+ * ## The one safety rule everything here is built around
+ *
+ * A read that FAILED and a slot that is EMPTY must never be the same value. The
+ * empty answer authorises writes (seed the slot); the failed answer must
+ * authorise nothing. {@link SharedDeviceCredentialRead} keeps them apart at the
+ * type level, and every decision below fails closed on anything that is not a
+ * positive `absent`/`present`.
+ *
+ * Platform-agnostic: the actual keychain / keystore access is injected as a
+ * {@link SharedDeviceCredentialStore} by `@oxyhq/services`. ESM-safe, no
+ * `require()`, no react/react-native/expo imports.
+ */
+
+import { logger } from '../logger';
+import type { AuthStateStore, PersistedAuthState } from './authStateStore';
+
+/**
+ * The zero-cookie device credential, as shared between apps. Exactly the pair
+ * `POST /session/device/token` takes — nothing else travels through the shared
+ * slot: no access token, no account id, no user id, no identity key.
+ */
+export interface SharedDeviceCredential {
+  deviceId: string;
+  deviceSecret: string;
+}
+
+/**
+ * The outcome of reading the shared slot. FOUR states, and the distinction
+ * between the last two is load-bearing:
+ *
+ * - `present`     — a well-formed credential was read.
+ * - `absent`      — the read SUCCEEDED and the slot is empty. The only state that
+ *                   may authorise seeding the slot.
+ * - `unavailable` — the read failed (keychain locked, keystore unreadable, the
+ *                   bridge returned something unrecognisable). Authorises
+ *                   nothing: not adoption, and above all not a write.
+ * - `unsupported` — this build has no shared slot at all (web, or a native app
+ *                   without the module linked). Not an error; simply means the
+ *                   app keeps its own per-app credential.
+ */
+export type SharedDeviceCredentialRead =
+  | { state: 'present'; credential: SharedDeviceCredential }
+  | { state: 'absent' }
+  | { state: 'unavailable'; cause: unknown }
+  | { state: 'unsupported' };
+
+/**
+ * The platform seam. `@oxyhq/services` implements this over the iOS Keychain
+ * Access Group (a dedicated `keychainService`) or the Android signature-protected
+ * `OxyDeviceSession` broker.
+ */
+export interface SharedDeviceCredentialStore {
+  /** Never throws — a failure is reported as `unavailable`, never as `absent`. */
+  read(): Promise<SharedDeviceCredentialRead>;
+  /**
+   * Publish the credential. Resolves `true` only when a read-back confirmed the
+   * exact bytes landed; `false` on any failure. Never throws.
+   */
+  publish(credential: SharedDeviceCredential): Promise<boolean>;
+  /** Drop this app's copy of the shared credential. Never throws. */
+  clear(): Promise<void>;
+}
+
+/** Why {@link decideSharedDeviceJoin} declined to adopt the shared credential. */
+export type SharedDeviceJoinSkipReason =
+  | 'shared-unsupported'
+  | 'shared-unreadable'
+  | 'shared-empty'
+  | 'local-credential-present';
+
+/** What a booting app should do with the shared slot it just read. */
+export type SharedDeviceJoinDecision =
+  | { action: 'adopt'; credential: SharedDeviceCredential }
+  | { action: 'skip'; reason: SharedDeviceJoinSkipReason };
+
+/** Why {@link decideSharedDevicePublish} declined to write the shared slot. */
+export type SharedDevicePublishSkipReason =
+  | 'shared-unsupported'
+  | 'shared-unreadable'
+  | 'already-current'
+  | 'owned-by-another-device';
+
+/** What an app that just PROVED a credential should do with the shared slot. */
+export type SharedDevicePublishDecision =
+  | { action: 'publish' }
+  | { action: 'skip'; reason: SharedDevicePublishSkipReason };
+
+/** The usable `{deviceId, deviceSecret}` pair in a persisted state, or null. */
+export function readLocalDeviceCredential(
+  state: PersistedAuthState | null,
+): SharedDeviceCredential | null {
+  if (!state?.deviceId || !state.deviceSecret) {
+    return null;
+  }
+  return { deviceId: state.deviceId, deviceSecret: state.deviceSecret };
+}
+
+/**
+ * Narrow an UNTRUSTED bridge payload into a {@link SharedDeviceCredentialRead}.
+ *
+ * Anything unrecognised resolves to `unavailable`, never `absent`. A native
+ * module returning a shape this build does not understand (an older app in the
+ * signing group, a partially-applied upgrade) means we do not KNOW whether the
+ * device has a shared session — and "do not know" must never authorise a write
+ * that would overwrite one.
+ */
+export function normalizeSharedDeviceSessionRead(raw: unknown): SharedDeviceCredentialRead {
+  if (!raw || typeof raw !== 'object') {
+    return { state: 'unavailable', cause: new Error('shared device session bridge returned a non-object') };
+  }
+  const payload = raw as Record<string, unknown>;
+  if (payload.status === 'absent') {
+    return { state: 'absent' };
+  }
+  if (payload.status === 'present') {
+    const deviceId = payload.deviceId;
+    const deviceSecret = payload.deviceSecret;
+    if (
+      typeof deviceId === 'string' &&
+      deviceId.length > 0 &&
+      typeof deviceSecret === 'string' &&
+      deviceSecret.length > 0
+    ) {
+      return { state: 'present', credential: { deviceId, deviceSecret } };
+    }
+    // A `present` verdict whose payload is incomplete is a broken slot, not an
+    // empty one. Reporting `absent` here would let the next successful sign-in
+    // overwrite whatever is really in there.
+    return {
+      state: 'unavailable',
+      cause: new Error('shared device session bridge reported `present` with an incomplete credential'),
+    };
+  }
+  if (payload.status === 'unavailable') {
+    const reason = typeof payload.reason === 'string' ? payload.reason : 'unknown';
+    return { state: 'unavailable', cause: new Error(`shared device session slot unavailable: ${reason}`) };
+  }
+  return {
+    state: 'unavailable',
+    cause: new Error(`shared device session bridge returned an unrecognised status: ${String(payload.status)}`),
+  };
+}
+
+/**
+ * Should this app adopt the shared credential? Pure.
+ *
+ * Adoption happens in exactly ONE case: the shared slot holds a credential and
+ * this app has none of its own. That single rule delivers the product
+ * requirement — a newly installed official app joins the device's existing
+ * session without another QR — while making the two failure modes that matter
+ * unreachable:
+ *
+ *  - An app that is already signed in is NEVER moved onto another credential, so
+ *    "no user is signed out merely because one app updates first" holds by
+ *    construction, in both upgrade directions.
+ *  - A failed read never looks like an empty slot, so a locked keychain resolves
+ *    to "keep what I have" rather than "this is a fresh device".
+ *
+ * The cost is stated plainly: two apps that each already own a DIFFERENT device
+ * session stay on their own until one of them loses its credential. Converging
+ * them would mean signing one of them out or a server-side device merge, and
+ * neither is something a boot path may do silently.
+ */
+export function decideSharedDeviceJoin(
+  local: PersistedAuthState | null,
+  shared: SharedDeviceCredentialRead,
+): SharedDeviceJoinDecision {
+  if (readLocalDeviceCredential(local) !== null) {
+    return { action: 'skip', reason: 'local-credential-present' };
+  }
+  switch (shared.state) {
+    case 'present':
+      return { action: 'adopt', credential: shared.credential };
+    case 'absent':
+      return { action: 'skip', reason: 'shared-empty' };
+    case 'unavailable':
+      return { action: 'skip', reason: 'shared-unreadable' };
+    case 'unsupported':
+      return { action: 'skip', reason: 'shared-unsupported' };
+  }
+}
+
+/**
+ * Should this app write the credential it just proved into the shared slot? Pure.
+ *
+ * `proven` means the server accepted it moments ago — a successful sign-in or a
+ * successful mint. Only a proven credential is ever published, so the slot can
+ * never be seeded with something no app could use.
+ *
+ * A slot already held by a DIFFERENT `deviceId` is left alone. Overwriting it
+ * would silently migrate every other app on this device onto our session at their
+ * next cold boot — a real, user-visible change of who they are signed in as, and
+ * not something a background persist may decide.
+ */
+export function decideSharedDevicePublish(
+  proven: SharedDeviceCredential,
+  shared: SharedDeviceCredentialRead,
+): SharedDevicePublishDecision {
+  switch (shared.state) {
+    case 'unsupported':
+      return { action: 'skip', reason: 'shared-unsupported' };
+    case 'unavailable':
+      return { action: 'skip', reason: 'shared-unreadable' };
+    case 'absent':
+      return { action: 'publish' };
+    case 'present': {
+      if (shared.credential.deviceId !== proven.deviceId) {
+        return { action: 'skip', reason: 'owned-by-another-device' };
+      }
+      if (shared.credential.deviceSecret === proven.deviceSecret) {
+        return { action: 'skip', reason: 'already-current' };
+      }
+      // Same device, newer secret. Sign-in rotates the secret (the mint does
+      // not), so the just-proven one is the credential a fresh install should
+      // join with.
+      return { action: 'publish' };
+    }
+  }
+}
+
+/** The result of {@link publishProvenDeviceCredential}, for logs and tests. */
+export type SharedDevicePublishOutcome =
+  | { status: 'published' }
+  | { status: 'publish-failed' }
+  | { status: 'skipped'; reason: SharedDevicePublishSkipReason };
+
+/**
+ * Read the shared slot, apply {@link decideSharedDevicePublish}, and write when
+ * it says so. Best-effort by contract: the caller's own durable credential is
+ * already persisted, so a failure here only means a future install will have to
+ * sign in interactively.
+ */
+export async function publishProvenDeviceCredential(deps: {
+  shared: SharedDeviceCredentialStore;
+  credential: SharedDeviceCredential;
+}): Promise<SharedDevicePublishOutcome> {
+  const read = await deps.shared.read();
+  const decision = decideSharedDevicePublish(deps.credential, read);
+  if (decision.action === 'skip') {
+    if (decision.reason === 'shared-unreadable') {
+      logger.debug(
+        'shared device credential slot unreadable — not publishing (an unreadable slot is never an empty one)',
+        { component: 'sharedDeviceCredential', method: 'publishProvenDeviceCredential' },
+      );
+    }
+    return { status: 'skipped', reason: decision.reason };
+  }
+  const published = await deps.shared.publish(deps.credential);
+  return published ? { status: 'published' } : { status: 'publish-failed' };
+}
+
+/**
+ * Wrap a platform {@link AuthStateStore} so that every durable credential it
+ * persists is ALSO mirrored into the shared slot.
+ *
+ * Writes mirror automatically; reads do NOT adopt. That split is deliberate:
+ *
+ *  - Mirroring on write is the right place because `save()` is where a proven
+ *    credential lands, on every lane there is — interactive sign-in, the cold
+ *    boot mint, the refresh scheduler, the 401 re-mint, shared-key recovery. One
+ *    seam, no lane left out, and no new call site to forget.
+ *  - Adopting on read would hide a change of WHO THIS APP IS SIGNED IN AS inside
+ *    a storage primitive, and would run on every `load()`. Adoption is an
+ *    explicit, once-per-boot cold-boot step instead (`shared-device-adopt`).
+ *
+ * `clear()` deliberately does NOT clear the shared slot. This app signing out is
+ * not authority over the device-wide join point: other apps may still be signed
+ * in on that same credential, and once the server session is really gone the
+ * credential mints `no_active_session` for everyone anyway.
+ */
+export function createSharedMirroringAuthStateStore(deps: {
+  local: AuthStateStore;
+  shared: SharedDeviceCredentialStore;
+}): AuthStateStore {
+  const { local, shared } = deps;
+  // Process-local memo of the credential we last observed the shared slot to
+  // hold. Purely an optimization to keep the refresh scheduler from re-reading
+  // the keychain every mint; a slot wiped out from under us is re-seeded on the
+  // next launch rather than mid-process.
+  let mirrored: SharedDeviceCredential | null = null;
+
+  return {
+    load: () => local.load(),
+    clear: () => local.clear(),
+    save: async (state) => {
+      // The durable local write is the contract this store owes its caller —
+      // run it first and report ITS result, unchanged. The mirror is additive.
+      const durablePersisted = await local.save(state);
+      const credential = readLocalDeviceCredential(state);
+      if (!credential) {
+        return durablePersisted;
+      }
+      if (
+        mirrored !== null &&
+        mirrored.deviceId === credential.deviceId &&
+        mirrored.deviceSecret === credential.deviceSecret
+      ) {
+        return durablePersisted;
+      }
+      try {
+        const outcome = await publishProvenDeviceCredential({ shared, credential });
+        if (outcome.status === 'published' || (outcome.status === 'skipped' && outcome.reason === 'already-current')) {
+          mirrored = credential;
+        }
+      } catch (error) {
+        // A store implementation is contractually non-throwing, but a mirror
+        // failure must never take down the durable write that already succeeded.
+        logger.debug(
+          'mirroring the device credential into the shared slot threw — the local credential is unaffected',
+          { component: 'sharedDeviceCredential', method: 'save' },
+          error,
+        );
+      }
+      return durablePersisted;
+    },
+  };
+}

--- a/packages/services/__tests__/android/encryptedPrefsRecoveryPolicy.test.ts
+++ b/packages/services/__tests__/android/encryptedPrefsRecoveryPolicy.test.ts
@@ -32,7 +32,20 @@ const ANDROID_SOURCE_ROOT = resolve(__dirname, '../../android/src/main/java/so/o
 
 /** The store whose loss is unrecoverable, named in failures so the stakes are legible. */
 const IRREPLACEABLE_STORE = 'oxy_shared_identity';
-const DISPOSABLE_STORE = 'oxy_background_session';
+
+/**
+ * Every store whose contents some other authority can re-create, and which
+ * therefore must NOT be allowed to escalate to a UID-shared master-key reset.
+ *
+ * `oxy_background_session` holds a credential the app re-provisions on its next
+ * foreground. `oxy_shared_device_session` holds the cross-app DeviceSession
+ * credential, which every signed-in app re-publishes from its own durable copy.
+ * Losing either costs at most one sign-in; escalating destroys an identity.
+ */
+const DISPOSABLE_STORES = [
+  { store: 'oxy_background_session', file: 'OxyBackgroundSessionStore.kt' },
+  { store: 'oxy_shared_device_session', file: 'OxyDeviceSessionStore.kt' },
+];
 
 /** Every `.kt` file under the android source tree, so a NEW store cannot hide. */
 function kotlinSources(dir: string): string[] {
@@ -65,44 +78,48 @@ describe('OxyEncryptedPrefs recovery policy', () => {
     // Vacuity floor: a broken path or a moved tree must fail here rather than
     // silently turn every assertion below into a pass over an empty list.
     const sources = kotlinSources(ANDROID_SOURCE_ROOT);
-    expect(sources.length).toBeGreaterThanOrEqual(6);
+    expect(sources.length).toBeGreaterThanOrEqual(9);
     expect(sources.some((f) => f.endsWith('OxyEncryptedPrefs.kt'))).toBe(true);
     expect(sources.some((f) => f.endsWith('OxyIdentityStore.kt'))).toBe(true);
     expect(sources.some((f) => f.endsWith('OxyBackgroundSessionStore.kt'))).toBe(true);
+    expect(sources.some((f) => f.endsWith('OxyDeviceSessionStore.kt'))).toBe(true);
   });
 
   test('every store states its recovery policy explicitly', () => {
     const sites = openCallSites();
-    // Two stores today. A THIRD failing here is the point: adding a store must be
-    // a deliberate choice about what it may destroy, reviewed with this rule in
+    // Three stores today. A FOURTH failing here is the point: adding a store must
+    // be a deliberate choice about what it may destroy, reviewed with this rule in
     // view — not something inherited by copying a neighbour.
-    expect(sites.map((s) => s.line)).toHaveLength(2);
+    expect(sites.map((s) => s.line)).toHaveLength(3);
     for (const site of sites) {
       expect(site.line).toMatch(/RecoveryPolicy\.(RebuildFileOnly|RegenerateSharedMasterKey)/);
     }
   });
 
-  test(`the disposable store cannot delete the master key that protects ${IRREPLACEABLE_STORE}`, () => {
-    const site = openCallSites().find((s) => s.file.endsWith('OxyBackgroundSessionStore.kt'));
-    expect(site).toBeDefined();
-    const line = site?.line ?? '';
-    expect(line).not.toHaveLength(0);
+  test.each(DISPOSABLE_STORES)(
+    `$store cannot delete the master key that protects ${IRREPLACEABLE_STORE}`,
+    ({ store, file }) => {
+      const site = openCallSites().find((s) => s.file.endsWith(file));
+      expect(site).toBeDefined();
+      const line = site?.line ?? '';
+      expect(line).not.toHaveLength(0);
 
-    // The whole safety property. Thrown rather than `expect`ed (jest's expect takes
-    // no message) so the failure explains what breaks and why, not just which
-    // substring was missing — whoever trips this needs the stakes, not a diff.
-    if (!line.includes('RecoveryPolicy.RebuildFileOnly')) {
-      throw new Error(
-        `${DISPOSABLE_STORE} must open with RecoveryPolicy.RebuildFileOnly.\n` +
-          `  found: ${line}\n\n` +
-          `It holds a credential the app re-provisions on its next foreground, so giving up ` +
-          `costs the user nothing. Escalating instead deletes the UID-shared androidx master ` +
-          `key, which makes every sibling Oxy store unreadable — including ${IRREPLACEABLE_STORE}, ` +
-          `the self-custody identity keypair, which CANNOT be re-created. As written, a widget's ` +
-          `throwaway credential failing to open would destroy the user's identity key.`,
-      );
-    }
-  });
+      // The whole safety property. Thrown rather than `expect`ed (jest's expect takes
+      // no message) so the failure explains what breaks and why, not just which
+      // substring was missing — whoever trips this needs the stakes, not a diff.
+      if (!line.includes('RecoveryPolicy.RebuildFileOnly')) {
+        throw new Error(
+          `${store} must open with RecoveryPolicy.RebuildFileOnly.\n` +
+            `  found: ${line}\n\n` +
+            `It holds data some other authority re-creates on demand, so giving up ` +
+            `costs the user at most one sign-in. Escalating instead deletes the UID-shared androidx ` +
+            `master key, which makes every sibling Oxy store unreadable — including ${IRREPLACEABLE_STORE}, ` +
+            `the self-custody identity keypair, which CANNOT be re-created. As written, a throwaway ` +
+            `credential failing to open would destroy the user's identity key.`,
+        );
+      }
+    },
+  );
 
   test('the identity store keeps its original escalating behaviour', () => {
     const site = openCallSites().find((s) => s.file.endsWith('OxyIdentityStore.kt'));

--- a/packages/services/__tests__/android/sharedDeviceSessionSeparation.test.ts
+++ b/packages/services/__tests__/android/sharedDeviceSessionSeparation.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Pins the separation the shared DeviceSession credential exists to create, and
+ * the manifest wiring that makes it enforceable.
+ *
+ * Two secrets can make an Oxy app boot signed in:
+ *
+ *   the Commons private identity key  — self-custody, IRREPLACEABLE, signs
+ *                                       identity approvals;
+ *   the DeviceSession credential      — an ordinary rotatable, server-revocable
+ *                                       `deviceId` + `deviceSecret`.
+ *
+ * An ordinary app needs the second. This file fails if the two ever start
+ * reaching into each other's storage, if the cross-process read stops being
+ * signature-gated, or if the hand-maintained authority lists drift apart.
+ *
+ * ## Why this test reads source text
+ *
+ * The same reason as `encryptedPrefsRecoveryPolicy.test.ts` next door: there is
+ * no gradle/android job in CI, so this Kotlin is not even COMPILED here, and
+ * exercising a real ContentProvider needs an instrumented device. A source
+ * invariant that runs on every `bun run test` is worth more than a perfect test
+ * that never runs.
+ *
+ * It is built to fail loudly rather than pass vacuously: every scan has a floor,
+ * and the authority comparison names the file that disagrees.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const PKG_ROOT = resolve(__dirname, '../..');
+
+const DEVICE_SESSION_SOURCES = [
+  'android/src/main/java/so/oxy/devicesession/OxyDeviceSessionStore.kt',
+  'android/src/main/java/so/oxy/devicesession/OxyDeviceSessionProvider.kt',
+  'android/src/main/java/so/oxy/devicesession/OxyDeviceSessionModule.kt',
+];
+
+const IDENTITY_SOURCES = [
+  'android/src/main/java/so/oxy/identity/OxyIdentityStore.kt',
+  'android/src/main/java/so/oxy/identity/OxyIdentityProvider.kt',
+  'android/src/main/java/so/oxy/identity/OxyIdentityModule.kt',
+];
+
+const PROVIDER_PLUGIN = 'plugins/withSharedDeviceSessionProvider.js';
+const READER_PLUGIN = 'plugins/withSharedDeviceSessionReader.js';
+const MODULE_KT = 'android/src/main/java/so/oxy/devicesession/OxyDeviceSessionModule.kt';
+
+const READ_DEVICE_SESSION_PERMISSION = 'so.oxy.shared.permission.READ_DEVICE_SESSION';
+const READ_IDENTITY_PERMISSION = 'so.oxy.shared.permission.READ_IDENTITY';
+
+function read(relative: string): string {
+  return readFileSync(resolve(PKG_ROOT, relative), 'utf8');
+}
+
+/**
+ * The file with comments stripped, so the boundary scan measures REFERENCES and
+ * not prose. The doc comments in these files talk about the identity store on
+ * purpose — explaining why the two are separate is the most useful thing they
+ * can say, and a gate that forbade saying it would be a gate against comments.
+ */
+function readCode(relative: string): string {
+  return read(relative)
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^[^\n"]*\/\/.*$/gm, '');
+}
+
+/**
+ * Every `so.oxy.…devicesession` authority string in a file, deduped and sorted.
+ * Matches the LITERAL strings in either quote style (Kotlin uses `"`, the
+ * plugins use `'`), so a list expressed as a template or a loop simply yields
+ * nothing here — which the floor below turns into a failure rather than a pass.
+ */
+function authoritiesIn(relative: string): string[] {
+  const matches = read(relative).match(/['"]so\.oxy\.[a-z.]*devicesession['"]/g) ?? [];
+  return Array.from(new Set(matches.map((m) => m.slice(1, -1)))).sort();
+}
+
+describe('shared DeviceSession credential — Android wiring', () => {
+  test('the files this suite asserts about are actually being read', () => {
+    // Vacuity floor. A moved or renamed file must fail here rather than silently
+    // turn every assertion below into a pass over an empty string.
+    for (const relative of [...DEVICE_SESSION_SOURCES, ...IDENTITY_SOURCES, PROVIDER_PLUGIN, READER_PLUGIN]) {
+      expect(read(relative).length).toBeGreaterThan(500);
+    }
+  });
+
+  test('the device-session tree never reaches into identity storage', () => {
+    // The separation, stated as code rather than as prose in a design doc. An
+    // app that only needs a session must not be able to obtain the key that
+    // signs identity approvals, and the first sign of that boundary eroding is
+    // one of these names appearing here.
+    const forbidden = ['OxyIdentityStore', 'OxyIdentityProvider', 'oxy_shared_identity', 'privateKey', 'publicKey'];
+    for (const relative of DEVICE_SESSION_SOURCES) {
+      const source = readCode(relative);
+      for (const name of forbidden) {
+        if (source.includes(name)) {
+          throw new Error(
+            `${relative} references '${name}'.\n\n` +
+              `The shared DeviceSession credential is deliberately separate from the self-custody ` +
+              `identity keypair: it is an ordinary rotatable, server-revocable secret, while the ` +
+              `identity key cannot be re-created if it leaks or is lost. Reaching across that ` +
+              `boundary is how "ordinary apps do not need Commons private key access" stops being true.`,
+          );
+        }
+      }
+    }
+  });
+
+  test('the identity tree never reaches into device-session storage', () => {
+    // The same wall, from the other side — so a future refactor cannot merge them
+    // by moving the code rather than by importing it.
+    for (const relative of IDENTITY_SOURCES) {
+      const source = readCode(relative);
+      expect(source).not.toContain('OxyDeviceSessionStore');
+      expect(source).not.toContain('oxy_shared_device_session');
+    }
+  });
+
+  test('the two stores are different encrypted files', () => {
+    // Same androidx master key, different files — so a stage-1 keyset heal on the
+    // disposable one cannot take the identity keypair with it.
+    expect(read(DEVICE_SESSION_SOURCES[0])).toContain('"oxy_shared_device_session"');
+    expect(read(IDENTITY_SOURCES[0])).toContain('"oxy_shared_identity"');
+  });
+
+  test('the cross-process read is signature-gated', () => {
+    const provider = read('android/src/main/java/so/oxy/devicesession/OxyDeviceSessionProvider.kt');
+    // Same-signature is the entire trust boundary for an Android app outside the
+    // shared UID. Without this an incorrectly-signed app reads the slot.
+    expect(provider).toContain('PackageManager.SIGNATURE_MATCH');
+    expect(provider).toContain('callingPackage ?: return false');
+  });
+
+  test('the provider is read-only across the process boundary', () => {
+    const provider = readCode('android/src/main/java/so/oxy/devicesession/OxyDeviceSessionProvider.kt');
+    // A sibling may JOIN the device session. Letting it write would let any
+    // same-signature app move every other app onto a session of its choosing.
+    expect(provider).toContain('if (method != METHOD_READ) return null');
+    expect(provider).not.toContain('OxyDeviceSessionStore.write');
+    expect(provider).not.toContain('OxyDeviceSessionStore.clear');
+  });
+
+  test('the provider maps each read outcome to its OWN status', () => {
+    // The rule the whole three-state design exists for: a store the provider
+    // could not READ must not be reported as a store that is EMPTY. The empty
+    // answer authorises the caller to seed the slot; the failed answer authorises
+    // nothing. Asserting per-arm rather than just "the file mentions
+    // STATUS_UNAVAILABLE" — a collapsed arm leaves the constant in the file.
+    const provider = readCode('android/src/main/java/so/oxy/devicesession/OxyDeviceSessionProvider.kt');
+    const arms: [string, string][] = [
+      ['Present', 'STATUS_PRESENT'],
+      ['Absent', 'STATUS_ABSENT'],
+      ['Unavailable', 'STATUS_UNAVAILABLE'],
+    ];
+    const marker = (name: string) => `is DeviceSessionRead.${name} ->`;
+    for (const [name, expected] of arms) {
+      const start = provider.indexOf(marker(name));
+      expect(start).toBeGreaterThanOrEqual(0);
+      const rest = provider.slice(start + marker(name).length);
+      const nextArm = arms
+        .map(([other]) => rest.indexOf(marker(other)))
+        .filter((index) => index >= 0);
+      const body = rest.slice(0, nextArm.length > 0 ? Math.min(...nextArm) : undefined);
+      const emitted = arms.map(([, status]) => status).filter((status) => body.includes(status));
+      if (emitted.join() !== expected) {
+        throw new Error(
+          `The provider's '${name}' arm emits ${emitted.join(', ') || '(no status)'}, expected ${expected}.\n\n` +
+            'Present / absent / unavailable are three different answers and only "absent" may ' +
+            'authorise a caller to write into the slot. An arm that reports a failed read as an ' +
+            'empty one is how a locked or broken keystore ends up overwriting a live session.',
+        );
+      }
+    }
+  });
+
+  test('the sweep never turns an unreadable source into an empty one', () => {
+    // Same rule, one layer up: the module merges several sources, and every
+    // `DeviceSessionRead.Absent` it PRODUCES must come from a peer that actually
+    // said `absent`. A fallback arm resolving to `Absent` — for an unrecognised
+    // status, say — silently converts "I could not tell" into "there is none".
+    const module = readCode(MODULE_KT);
+    const producing = module
+      .split('\n')
+      .filter((line) => line.includes('-> DeviceSessionRead.Absent'));
+    // Floor: if this finds nothing the assertion below is vacuous.
+    expect(producing.length).toBeGreaterThanOrEqual(1);
+    for (const line of producing) {
+      if (!line.includes('STATUS_ABSENT')) {
+        throw new Error(
+          `${MODULE_KT} produces DeviceSessionRead.Absent from a source that did not report absent:\n` +
+            `  ${line.trim()}\n\n` +
+            'Only a peer answering STATUS_ABSENT may yield Absent. Everything else — an ' +
+            'unrecognised status, a failed call, a peer that could not read its own store — is ' +
+            'Unavailable, because the JS side treats Absent as permission to seed the slot.',
+        );
+      }
+    }
+  });
+
+  test('the manifest gate uses its OWN signature-level permission', () => {
+    const plugin = readCode(PROVIDER_PLUGIN);
+    expect(plugin).toContain(READ_DEVICE_SESSION_PERMISSION);
+    expect(plugin).toContain("'android:protectionLevel': 'signature'");
+    expect(plugin).toContain("'android:permission': READ_DEVICE_SESSION_PERMISSION");
+    // Distinct from the identity permission: granting an app the right to join a
+    // device session must not grant it the right to read an identity key.
+    expect(READ_DEVICE_SESSION_PERMISSION).not.toBe(READ_IDENTITY_PERMISSION);
+    expect(plugin).not.toContain(READ_IDENTITY_PERMISSION);
+    expect(readCode(READER_PLUGIN)).not.toContain(READ_IDENTITY_PERMISSION);
+  });
+
+  test('the reader plugin requests the permission but hosts nothing', () => {
+    const reader = readCode(READER_PLUGIN);
+    expect(reader).toContain(READ_DEVICE_SESSION_PERMISSION);
+    expect(reader).not.toContain('OxyDeviceSessionProvider');
+    expect(reader).not.toContain('app.provider');
+  });
+
+  test('the Kotlin sweep and BOTH plugins list exactly the same authorities', () => {
+    const kotlin = authoritiesIn(MODULE_KT);
+    const provider = authoritiesIn(PROVIDER_PLUGIN);
+    const reader = authoritiesIn(READER_PLUGIN);
+
+    // Floor first: three empty lists would otherwise "agree" perfectly.
+    expect(kotlin.length).toBeGreaterThanOrEqual(2);
+
+    // A `<queries>` entry missing for an authority the Kotlin sweeps means
+    // Android 11+ package-visibility hides that provider and the sweep silently
+    // finds nothing — a drift with no error message anywhere.
+    if (provider.join() !== kotlin.join() || reader.join() !== kotlin.join()) {
+      throw new Error(
+        'The shared DeviceSession provider authorities have drifted.\n' +
+          `  ${MODULE_KT}: ${kotlin.join(', ') || '(none)'}\n` +
+          `  ${PROVIDER_PLUGIN}: ${provider.join(', ') || '(none)'}\n` +
+          `  ${READER_PLUGIN}: ${reader.join(', ') || '(none)'}\n\n` +
+          'The Kotlin list decides who is swept; the plugin lists decide who is VISIBLE ' +
+          'under Android 11+ package filtering. An authority in one and not the others is ' +
+          'either never asked or asked and invisible — both fail silently, with the app ' +
+          'simply never joining the device session.',
+      );
+    }
+  });
+
+  test('the native module is registered for autolinking', () => {
+    // A module missing from here resolves to `null` through
+    // `requireOptionalNativeModule`, which the JS side reads as `unsupported` —
+    // no error, the feature is just off.
+    const config = JSON.parse(read('expo-module.config.json')) as { android?: { modules?: string[] } };
+    expect(config.android?.modules).toContain('so.oxy.devicesession.OxyDeviceSessionModule');
+  });
+
+  test('the native sources ship in the published package', () => {
+    const pkg = JSON.parse(read('package.json')) as { files?: string[] };
+    expect(pkg.files).toContain('android/src');
+    expect(pkg.files).toContain('plugins');
+  });
+});

--- a/packages/services/__tests__/android/sharedDeviceSessionSeparation.test.ts
+++ b/packages/services/__tests__/android/sharedDeviceSessionSeparation.test.ts
@@ -65,6 +65,35 @@ function readCode(relative: string): string {
 }
 
 /**
+ * The body of the brace-delimited block that follows `header`, by brace
+ * matching.
+ *
+ * Needed because the arms of a `when` are only bounded by the block's closing
+ * brace: scanning "from this arm to the next one" runs the LAST arm to the end
+ * of the file, where the companion object's constants make every assertion about
+ * that arm pass.
+ */
+function blockAfter(source: string, header: string): string {
+  const start = source.indexOf(header);
+  if (start < 0) {
+    throw new Error(`could not find '${header}'`);
+  }
+  const open = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') {
+      depth += 1;
+    } else if (source[i] === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(open + 1, i);
+      }
+    }
+  }
+  throw new Error(`unterminated block after '${header}'`);
+}
+
+/**
  * Every `so.oxy.…devicesession` authority string in a file, deduped and sorted.
  * Matches the LITERAL strings in either quote style (Kotlin uses `"`, the
  * plugins use `'`), so a list expressed as a template or a loop simply yields
@@ -147,6 +176,7 @@ describe('shared DeviceSession credential — Android wiring', () => {
     // nothing. Asserting per-arm rather than just "the file mentions
     // STATUS_UNAVAILABLE" — a collapsed arm leaves the constant in the file.
     const provider = readCode('android/src/main/java/so/oxy/devicesession/OxyDeviceSessionProvider.kt');
+    const when = blockAfter(provider, 'return when (val read = OxyDeviceSessionStore.read(ctx))');
     const arms: [string, string][] = [
       ['Present', 'STATUS_PRESENT'],
       ['Absent', 'STATUS_ABSENT'],
@@ -154,9 +184,9 @@ describe('shared DeviceSession credential — Android wiring', () => {
     ];
     const marker = (name: string) => `is DeviceSessionRead.${name} ->`;
     for (const [name, expected] of arms) {
-      const start = provider.indexOf(marker(name));
+      const start = when.indexOf(marker(name));
       expect(start).toBeGreaterThanOrEqual(0);
-      const rest = provider.slice(start + marker(name).length);
+      const rest = when.slice(start + marker(name).length);
       const nextArm = arms
         .map(([other]) => rest.indexOf(marker(other)))
         .filter((index) => index >= 0);

--- a/packages/services/android/src/main/java/so/oxy/devicesession/OxyDeviceSessionModule.kt
+++ b/packages/services/android/src/main/java/so/oxy/devicesession/OxyDeviceSessionModule.kt
@@ -1,0 +1,178 @@
+package so.oxy.devicesession
+
+import android.content.Context
+import android.net.Uri
+import android.os.Bundle
+import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+/**
+ * JS bridge for the shared DeviceSession credential.
+ *
+ * - `read` resolves the credential this DEVICE holds, from the sibling providers
+ *   first and this app's own store second (see [readShared] for why that order).
+ * - `write` publishes into this app's own store only, and reports whether a
+ *   read-back confirmed it.
+ * - `clear` drops this app's copy.
+ *
+ * ## `read` returns a STATUS, not a nullable value
+ *
+ * The three answers "here it is", "there is none" and "I could not tell" are
+ * genuinely different, and only the second one authorises the JS side to seed the
+ * slot. A nullable return would merge the last two, and the merged value reads as
+ * "fresh device" — which is exactly how a locked or broken keystore ends up
+ * overwriting a live session. So every path here reports its status explicitly,
+ * and never degrades a failure into an absence.
+ *
+ * Return shapes:
+ * ```
+ * { "status": "present", "deviceId": "...", "deviceSecret": "..." }
+ * { "status": "absent" }
+ * { "status": "unavailable", "reason": "<ExceptionClassName>" }
+ * ```
+ *
+ * Plain scalars in, a plain `Map` out — never an Expo `Record`. This package
+ * ships as SOURCE that each consuming app compiles, so the annotation processing
+ * a `Record` needs to become introspectable does not necessarily run in the
+ * consumer's build; the one `Record` this package ever had failed to convert on a
+ * real device and stored nothing, silently. See the long note in
+ * `so.oxy.session.OxyBackgroundSessionModule` before reaching for one here.
+ */
+class OxyDeviceSessionModule : Module() {
+  private val context: Context
+    get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
+
+  override fun definition() = ModuleDefinition {
+    Name("OxyDeviceSession")
+
+    AsyncFunction("read") {
+      readShared()
+    }
+
+    AsyncFunction("write") { deviceId: String, deviceSecret: String ->
+      if (deviceId.isEmpty() || deviceSecret.isEmpty()) {
+        return@AsyncFunction false
+      }
+      OxyDeviceSessionStore.write(context, deviceId, deviceSecret)
+    }
+
+    AsyncFunction("clear") {
+      OxyDeviceSessionStore.clear(context)
+    }
+  }
+
+  /**
+   * Providers FIRST, this app's own store second.
+   *
+   * Under `android:sharedUserId="so.oxy.shared"` every Oxy app sees one data
+   * directory, so for a UID member the local file IS the group's file and the
+   * order changes nothing. It matters for a same-signature app OUTSIDE the UID:
+   * there the local file is a private mirror of whatever that app itself last
+   * wrote, so reading it first would shadow the group's real credential forever.
+   *
+   * `unavailable` is sticky across the whole sweep: if ANY source could not be
+   * read and none produced a credential, the answer is `unavailable`, not
+   * `absent`. The pessimistic merge is the point — the optimistic one authorises
+   * a write.
+   */
+  private fun readShared(): Map<String, String> {
+    var unavailableReason: String? = null
+
+    for (authority in PROVIDER_AUTHORITIES) {
+      when (val read = callProvider(authority)) {
+        is DeviceSessionRead.Present -> return present(read)
+        is DeviceSessionRead.Unavailable -> unavailableReason = unavailableReason ?: read.reason
+        // Absent, or no provider there at all (not installed, refused, threw) —
+        // neither is evidence about the other sources, so keep looking.
+        else -> Unit
+      }
+    }
+
+    when (val local = OxyDeviceSessionStore.read(context)) {
+      is DeviceSessionRead.Present -> return present(local)
+      is DeviceSessionRead.Unavailable -> unavailableReason = unavailableReason ?: local.reason
+      is DeviceSessionRead.Absent -> Unit
+    }
+
+    val reason = unavailableReason
+    return if (reason != null) {
+      mapOf(
+        OxyDeviceSessionProvider.KEY_STATUS to OxyDeviceSessionProvider.STATUS_UNAVAILABLE,
+        OxyDeviceSessionProvider.KEY_REASON to reason,
+      )
+    } else {
+      mapOf(OxyDeviceSessionProvider.KEY_STATUS to OxyDeviceSessionProvider.STATUS_ABSENT)
+    }
+  }
+
+  private fun present(read: DeviceSessionRead.Present): Map<String, String> = mapOf(
+    OxyDeviceSessionProvider.KEY_STATUS to OxyDeviceSessionProvider.STATUS_PRESENT,
+    OxyDeviceSessionStore.KEY_DEVICE_ID to read.deviceId,
+    OxyDeviceSessionStore.KEY_DEVICE_SECRET to read.deviceSecret,
+  )
+
+  /**
+   * Call one sibling provider. `null` means "nothing to learn from this one" —
+   * the app is not installed, package visibility hid it, the permission was
+   * refused, or the call threw. A provider that answered but could not read its
+   * own store returns [DeviceSessionRead.Unavailable], which the sweep keeps.
+   */
+  private fun callProvider(authority: String): DeviceSessionRead? = runCatching {
+    val uri = Uri.parse("content://$authority")
+    val bundle: Bundle = context.contentResolver.call(
+      uri,
+      OxyDeviceSessionProvider.METHOD_READ,
+      null,
+      null,
+    ) ?: return@runCatching null
+
+    when (bundle.getString(OxyDeviceSessionProvider.KEY_STATUS)) {
+      OxyDeviceSessionProvider.STATUS_PRESENT -> {
+        val deviceId = bundle.getString(OxyDeviceSessionStore.KEY_DEVICE_ID)
+        val deviceSecret = bundle.getString(OxyDeviceSessionStore.KEY_DEVICE_SECRET)
+        if (deviceId.isNullOrEmpty() || deviceSecret.isNullOrEmpty()) {
+          // A `present` verdict with an incomplete payload is a broken peer, not
+          // an empty device.
+          DeviceSessionRead.Unavailable("IncompleteProviderPayload")
+        } else {
+          DeviceSessionRead.Present(deviceId, deviceSecret)
+        }
+      }
+      OxyDeviceSessionProvider.STATUS_ABSENT -> DeviceSessionRead.Absent
+      OxyDeviceSessionProvider.STATUS_UNAVAILABLE ->
+        DeviceSessionRead.Unavailable(
+          bundle.getString(OxyDeviceSessionProvider.KEY_REASON) ?: "PeerUnavailable",
+        )
+      // An older sibling that predates this protocol. It said something we do not
+      // understand, so we have learned nothing — never read that as "absent".
+      else -> DeviceSessionRead.Unavailable("UnrecognisedProviderStatus")
+    }
+  }.getOrNull()
+
+  companion object {
+    /**
+     * Sibling authorities to sweep, in order. Each official Oxy Android app hosts
+     * the provider at `${applicationId}.devicesession` via the
+     * `withSharedDeviceSession` config plugin, and both the prod and `.dev`
+     * variants are listed so a developer build can join a device too.
+     *
+     * MAINTAINED LIST, and the constraint on it is specific: every entry must be
+     * an app inside the `so.oxy.shared` UID. UID members all serve ONE file, so
+     * the sweep is deterministic no matter which of them answers first. Adding an
+     * app that is same-signature but NOT in the UID would put a second,
+     * independent copy of "the shared credential" into the sweep and make the
+     * winner depend on list order.
+     *
+     * The same authorities must also be added to the `<queries>` block in
+     * `withSharedDeviceSession.js`, or Android 11+ package-visibility filtering
+     * hides them from `ContentResolver.call` and the sweep silently finds nothing.
+     */
+    private val PROVIDER_AUTHORITIES = listOf(
+      "so.oxy.accounts.devicesession",
+      "so.oxy.accounts.dev.devicesession",
+      "so.oxy.commons.devicesession",
+      "so.oxy.commons.dev.devicesession",
+    )
+  }
+}

--- a/packages/services/android/src/main/java/so/oxy/devicesession/OxyDeviceSessionProvider.kt
+++ b/packages/services/android/src/main/java/so/oxy/devicesession/OxyDeviceSessionProvider.kt
@@ -1,0 +1,99 @@
+package so.oxy.devicesession
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Context
+import android.content.pm.PackageManager
+import android.database.Cursor
+import android.net.Uri
+import android.os.Bundle
+
+/**
+ * Cross-process READ surface for the shared DeviceSession credential, declared
+ * per-app by the `withSharedDeviceSession` config plugin at authority
+ * `${applicationId}.devicesession` behind a `signature`-level permission.
+ *
+ * The signature check below is belt-and-suspenders on top of that permission:
+ * even if the manifest gate were ever misconfigured, a differently-signed caller
+ * still gets nothing. Same-signature is the whole trust boundary — an
+ * incorrectly-signed app cannot read this slot, and there is no other way in.
+ *
+ * READ-ONLY across the process boundary, deliberately. A caller may join the
+ * device's session; it may not seed or overwrite another app's. Writes happen
+ * only in-process via [OxyDeviceSessionModule], against this app's own store.
+ *
+ * What crosses the boundary is a session credential — never the identity
+ * keypair, which lives behind `so.oxy.identity.OxyIdentityProvider` under a
+ * different permission. That separation is the point.
+ *
+ * All standard CRUD operations are no-ops; this provider exists solely for the
+ * `call()` channel.
+ */
+class OxyDeviceSessionProvider : ContentProvider() {
+  override fun onCreate(): Boolean = true
+
+  override fun call(method: String, arg: String?, extras: Bundle?): Bundle? {
+    if (method != METHOD_READ) return null
+    val ctx = context ?: return null
+    if (!callerSignatureMatches(ctx)) return null
+
+    return when (val read = OxyDeviceSessionStore.read(ctx)) {
+      is DeviceSessionRead.Present -> Bundle().apply {
+        putString(KEY_STATUS, STATUS_PRESENT)
+        putString(OxyDeviceSessionStore.KEY_DEVICE_ID, read.deviceId)
+        putString(OxyDeviceSessionStore.KEY_DEVICE_SECRET, read.deviceSecret)
+      }
+      is DeviceSessionRead.Absent -> Bundle().apply { putString(KEY_STATUS, STATUS_ABSENT) }
+      // Reported, not swallowed. A null here would be indistinguishable from
+      // "this app has no credential", and the caller would go on to treat the
+      // device as fresh.
+      is DeviceSessionRead.Unavailable -> Bundle().apply {
+        putString(KEY_STATUS, STATUS_UNAVAILABLE)
+        putString(KEY_REASON, read.reason)
+      }
+    }
+  }
+
+  /**
+   * True when the calling package shares this app's signing certificate. Uses
+   * `checkSignatures` (deprecated but still the simplest correct cross-package
+   * signature comparison; returns SIGNATURE_MATCH only for same-cert apps).
+   */
+  private fun callerSignatureMatches(ctx: Context): Boolean {
+    val caller = callingPackage ?: return false
+    return runCatching {
+      @Suppress("DEPRECATION")
+      ctx.packageManager.checkSignatures(caller, ctx.packageName) == PackageManager.SIGNATURE_MATCH
+    }.getOrDefault(false)
+  }
+
+  override fun query(
+    uri: Uri,
+    projection: Array<out String>?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+    sortOrder: String?
+  ): Cursor? = null
+
+  override fun getType(uri: Uri): String? = null
+
+  override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+  override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+
+  override fun update(
+    uri: Uri,
+    values: ContentValues?,
+    selection: String?,
+    selectionArgs: Array<out String>?
+  ): Int = 0
+
+  companion object {
+    const val METHOD_READ = "read"
+    const val KEY_STATUS = "status"
+    const val KEY_REASON = "reason"
+    const val STATUS_PRESENT = "present"
+    const val STATUS_ABSENT = "absent"
+    const val STATUS_UNAVAILABLE = "unavailable"
+  }
+}

--- a/packages/services/android/src/main/java/so/oxy/devicesession/OxyDeviceSessionStore.kt
+++ b/packages/services/android/src/main/java/so/oxy/devicesession/OxyDeviceSessionStore.kt
@@ -1,0 +1,115 @@
+package so.oxy.devicesession
+
+import android.content.Context
+import android.content.SharedPreferences
+import so.oxy.storage.OxyEncryptedPrefs
+import so.oxy.storage.RecoveryPolicy
+
+/**
+ * What a read of the shared slot found.
+ *
+ * THREE outcomes, and the difference between the last two is the entire safety
+ * property of this file. An EMPTY slot authorises a write (seed the device
+ * session); a slot that could not be READ must authorise nothing, because it may
+ * hold a live session belonging to someone still signed in. Collapsing them —
+ * which a plain nullable return would do — is how a locked or broken keystore
+ * gets mistaken for a fresh device.
+ */
+internal sealed interface DeviceSessionRead {
+  data class Present(val deviceId: String, val deviceSecret: String) : DeviceSessionRead
+  object Absent : DeviceSessionRead
+  /** [reason] is an exception CLASS NAME only — never a message, never a value. */
+  data class Unavailable(val reason: String) : DeviceSessionRead
+}
+
+/**
+ * The cross-app DeviceSession credential — `deviceId` + `deviceSecret`, and
+ * nothing else.
+ *
+ * This is NOT the identity keypair. `so.oxy.identity.OxyIdentityStore` holds the
+ * self-custody private key that signs identity approvals and cannot be
+ * re-created; this file holds an ordinary session credential the server can
+ * revoke and any signed-in app can re-publish. They are separate files behind
+ * separate providers with separate permissions precisely so an app that only
+ * needs a session is never handed the key.
+ *
+ * Under `android:sharedUserId="so.oxy.shared"` every Oxy app sees ONE data
+ * directory, so this file is literally shared between them — that is the primary
+ * transport, and [OxyDeviceSessionProvider] extends the same bytes to a
+ * same-signature app outside the UID.
+ */
+internal object OxyDeviceSessionStore {
+  /**
+   * Global (not package-suffixed) on purpose — the opposite choice from
+   * `oxy_background_session`, and for the opposite reason. That store is
+   * per-app precisely so one app cannot touch another's widget credential. This
+   * one EXISTS to be one value shared by every app in the UID; scoping it per
+   * package would give each app its own copy and defeat the whole point.
+   */
+  const val PREFS_NAME = "oxy_shared_device_session"
+  const val KEY_DEVICE_ID = "deviceId"
+  const val KEY_DEVICE_SECRET = "deviceSecret"
+
+  /**
+   * [RecoveryPolicy.RebuildFileOnly] — this store must NEVER escalate to a
+   * UID-shared master-key reset.
+   *
+   * What it holds is DERIVED: every signed-in app re-publishes the credential
+   * from its own durable copy, so losing this file costs at most one interactive
+   * sign-in on a device that has no other Oxy app installed. A master-key reset
+   * would wipe every other Oxy store sharing the alias — including the
+   * self-custody identity keypair, which is IRREPLACEABLE. Trading someone's
+   * unrecoverable identity to save a credential we can simply re-publish is never
+   * the right trade, so the escalation is not merely discouraged here, it is
+   * unreachable.
+   *
+   * Consequence worth stating: a stage-1 heal WIPES this file. That surfaces as
+   * `Absent`, which is honest — after the wipe the slot really is empty, and the
+   * next successful mint in any app re-seeds it.
+   */
+  private fun prefs(context: Context): SharedPreferences =
+    OxyEncryptedPrefs.open(context, PREFS_NAME, RecoveryPolicy.RebuildFileOnly)
+
+  /**
+   * Read the credential. A thrown open (the keyset is unreadable and the policy
+   * above refuses to escalate) is reported as [DeviceSessionRead.Unavailable] —
+   * never as absent.
+   */
+  fun read(context: Context): DeviceSessionRead =
+    runCatching {
+      val p = prefs(context)
+      val deviceId = p.getString(KEY_DEVICE_ID, null)
+      val deviceSecret = p.getString(KEY_DEVICE_SECRET, null)
+      if (deviceId.isNullOrEmpty() || deviceSecret.isNullOrEmpty()) {
+        DeviceSessionRead.Absent
+      } else {
+        DeviceSessionRead.Present(deviceId, deviceSecret)
+      }
+    }.getOrElse { DeviceSessionRead.Unavailable(it.javaClass.simpleName) }
+
+  /**
+   * Replace the credential, returning whether a read-back confirmed it landed.
+   *
+   * The read-back is the contract JS relies on: a fresh install adopts whatever
+   * is in this slot, so publishing a value that did not actually persist would
+   * send it into a mint that can never succeed.
+   *
+   * `commit()` (synchronous) so a cross-process reader firing immediately after
+   * the write sees the flushed value.
+   */
+  fun write(context: Context, deviceId: String, deviceSecret: String): Boolean =
+    runCatching {
+      val p = prefs(context)
+      p.edit()
+        .putString(KEY_DEVICE_ID, deviceId)
+        .putString(KEY_DEVICE_SECRET, deviceSecret)
+        .commit()
+      p.getString(KEY_DEVICE_ID, null) == deviceId &&
+        p.getString(KEY_DEVICE_SECRET, null) == deviceSecret
+    }.getOrDefault(false)
+
+  /** Drop the shared credential. Best-effort; safe to call when already empty. */
+  fun clear(context: Context) {
+    runCatching { prefs(context).edit().clear().commit() }
+  }
+}

--- a/packages/services/expo-module.config.json
+++ b/packages/services/expo-module.config.json
@@ -6,6 +6,7 @@
   "android": {
     "modules": [
       "so.oxy.identity.OxyIdentityModule",
+      "so.oxy.devicesession.OxyDeviceSessionModule",
       "so.oxy.session.OxyBackgroundSessionModule"
     ]
   }

--- a/packages/services/plugins/withSharedDeviceSessionProvider.js
+++ b/packages/services/plugins/withSharedDeviceSessionProvider.js
@@ -1,0 +1,102 @@
+/**
+ * Config plugin: withSharedDeviceSessionProvider (UID-member hub apps).
+ *
+ * The shared DeviceSession credential is how several official Oxy apps end up on
+ * ONE `DeviceSession` — and therefore one globally active account context —
+ * WITHOUT any of them reading Commons's private identity key. This plugin wires
+ * the Android side of `@oxyhq/services`:
+ *
+ *  - Defines a `signature`-level permission
+ *    `so.oxy.shared.permission.READ_DEVICE_SESSION`. `signature` means only apps
+ *    signed with the SAME certificate (the shared Oxy release keystore) can hold
+ *    it — the trust boundary is the signing key, not the deprecated `sharedUserId`.
+ *  - Requests that same permission so this app can also read cross-authority.
+ *  - Declares `OxyDeviceSessionProvider` at authority
+ *    `${applicationId}.devicesession` (AGP substitutes `${applicationId}` at
+ *    build), guarded by that permission. The provider is READ-only across the
+ *    process boundary: a sibling may join the device session, never overwrite it.
+ *  - Adds `<queries>` entries so Android 11+ package-visibility filtering never
+ *    hides the sibling providers from the resolver.
+ *
+ * WHICH APPS USE THIS PLUGIN: exactly the apps listed in `PROVIDER_AUTHORITIES`
+ * below, which must be apps inside the `so.oxy.shared` UID. UID members share one
+ * data directory, so they all serve the SAME file and the sweep in
+ * `OxyDeviceSessionModule` is deterministic whichever one answers. An app that is
+ * same-signature but outside that UID must use `withSharedDeviceSessionReader`
+ * instead — hosting from there would publish a second, independent copy of "the
+ * shared credential" and make the winner depend on list order.
+ *
+ * Keep this list identical to `PROVIDER_AUTHORITIES` in
+ * `android/src/main/java/so/oxy/devicesession/OxyDeviceSessionModule.kt`.
+ *
+ * This is deliberately a SEPARATE permission and a SEPARATE provider from
+ * `withSharedIdentityProvider`. Two secrets with different blast radii: the
+ * identity key is self-custody and irreplaceable, the device credential is
+ * server-revocable and re-publishable. An app that only needs a session gets only
+ * the second one.
+ */
+const { withAndroidManifest } = require('@expo/config-plugins');
+
+const READ_DEVICE_SESSION_PERMISSION = 'so.oxy.shared.permission.READ_DEVICE_SESSION';
+const PROVIDER_CLASS = 'so.oxy.devicesession.OxyDeviceSessionProvider';
+const PROVIDER_AUTHORITIES = [
+  'so.oxy.accounts.devicesession',
+  'so.oxy.accounts.dev.devicesession',
+  'so.oxy.commons.devicesession',
+  'so.oxy.commons.dev.devicesession',
+];
+
+module.exports = function withSharedDeviceSessionProvider(config) {
+  return withAndroidManifest(config, (modConfig) => {
+    const manifest = modConfig.modResults.manifest;
+
+    // 1. Define the signature-level permission.
+    manifest['permission'] = manifest['permission'] ?? [];
+    if (!manifest['permission'].some((p) => p.$['android:name'] === READ_DEVICE_SESSION_PERMISSION)) {
+      manifest['permission'].push({
+        $: {
+          'android:name': READ_DEVICE_SESSION_PERMISSION,
+          'android:protectionLevel': 'signature',
+        },
+      });
+    }
+
+    // 2. Request it (a hub app reads its siblings too — prod ⇆ dev variant).
+    manifest['uses-permission'] = manifest['uses-permission'] ?? [];
+    if (!manifest['uses-permission'].some((p) => p.$['android:name'] === READ_DEVICE_SESSION_PERMISSION)) {
+      manifest['uses-permission'].push({ $: { 'android:name': READ_DEVICE_SESSION_PERMISSION } });
+    }
+
+    // 3. Make the sibling provider authorities visible under package filtering.
+    manifest['queries'] = manifest['queries'] ?? [];
+    if (manifest['queries'].length === 0) {
+      manifest['queries'].push({});
+    }
+    const queries = manifest['queries'][0];
+    queries.provider = queries.provider ?? [];
+    for (const authority of PROVIDER_AUTHORITIES) {
+      if (!queries.provider.some((p) => p.$['android:authorities'] === authority)) {
+        queries.provider.push({ $: { 'android:authorities': authority } });
+      }
+    }
+
+    // 4. Host the provider.
+    const app = manifest.application?.[0];
+    if (!app) {
+      throw new Error('withSharedDeviceSessionProvider: AndroidManifest has no <application>');
+    }
+    app.provider = app.provider ?? [];
+    if (!app.provider.some((p) => p.$['android:name'] === PROVIDER_CLASS)) {
+      app.provider.push({
+        $: {
+          'android:name': PROVIDER_CLASS,
+          'android:authorities': '${applicationId}.devicesession',
+          'android:exported': 'true',
+          'android:permission': READ_DEVICE_SESSION_PERMISSION,
+        },
+      });
+    }
+
+    return modConfig;
+  });
+};

--- a/packages/services/plugins/withSharedDeviceSessionReader.js
+++ b/packages/services/plugins/withSharedDeviceSessionReader.js
@@ -1,0 +1,57 @@
+/**
+ * Config plugin: withSharedDeviceSessionReader (every other official Oxy app).
+ *
+ * A reader app JOINS the device's existing session — it adopts the shared
+ * `deviceId` + `deviceSecret` a hub app published, so it lands signed in with no
+ * QR and, crucially, without ever asking for Commons's private identity key.
+ * This plugin wires the minimal Android side of `@oxyhq/services`:
+ *
+ *  - Requests the `signature`-level permission
+ *    `so.oxy.shared.permission.READ_DEVICE_SESSION` (defined by the hub apps).
+ *    Because it is `signature`, it is granted only when this app is signed with
+ *    the SAME certificate as the hub — that is the entire trust boundary, and it
+ *    is what makes an incorrectly-signed app unable to read the slot.
+ *  - Adds `<queries>` entries for the hub authorities so package-visibility
+ *    filtering (Android 11+) never hides them from `ContentResolver.call`.
+ *
+ * The provider itself is declared only by the hub apps
+ * (`withSharedDeviceSessionProvider`) — see the note there about why hosting is
+ * restricted to apps inside the `so.oxy.shared` UID.
+ *
+ * Keep this list identical to `PROVIDER_AUTHORITIES` in
+ * `android/src/main/java/so/oxy/devicesession/OxyDeviceSessionModule.kt`.
+ */
+const { withAndroidManifest } = require('@expo/config-plugins');
+
+const READ_DEVICE_SESSION_PERMISSION = 'so.oxy.shared.permission.READ_DEVICE_SESSION';
+const PROVIDER_AUTHORITIES = [
+  'so.oxy.accounts.devicesession',
+  'so.oxy.accounts.dev.devicesession',
+  'so.oxy.commons.devicesession',
+  'so.oxy.commons.dev.devicesession',
+];
+
+module.exports = function withSharedDeviceSessionReader(config) {
+  return withAndroidManifest(config, (modConfig) => {
+    const manifest = modConfig.modResults.manifest;
+
+    manifest['uses-permission'] = manifest['uses-permission'] ?? [];
+    if (!manifest['uses-permission'].some((p) => p.$['android:name'] === READ_DEVICE_SESSION_PERMISSION)) {
+      manifest['uses-permission'].push({ $: { 'android:name': READ_DEVICE_SESSION_PERMISSION } });
+    }
+
+    manifest['queries'] = manifest['queries'] ?? [];
+    if (manifest['queries'].length === 0) {
+      manifest['queries'].push({});
+    }
+    const queries = manifest['queries'][0];
+    queries.provider = queries.provider ?? [];
+    for (const authority of PROVIDER_AUTHORITIES) {
+      if (!queries.provider.some((p) => p.$['android:authorities'] === authority)) {
+        queries.provider.push({ $: { 'android:authorities': authority } });
+      }
+    }
+
+    return modConfig;
+  });
+};

--- a/packages/services/src/ui/boot/runProviderColdBoot.ts
+++ b/packages/services/src/ui/boot/runProviderColdBoot.ts
@@ -8,6 +8,7 @@ import {
 } from '@oxyhq/core';
 import type { SessionClient } from '@oxyhq/core';
 import { loadPersistedDeviceCredential } from '../utils/deviceCredential';
+import { createPlatformSharedDeviceCredentialStore } from '../session/sharedDeviceCredentialStore';
 import { tryCompleteOAuthReturn } from '../utils/oauthReturn';
 import { isWebBrowser } from '../utils/isWebBrowser';
 import { isNetConnectivityExplicitlyOffline } from '../utils/netConnectivity';
@@ -161,6 +162,12 @@ export async function runProviderColdBoot(opts: RunProviderColdBootOptions): Pro
       platform: { isWeb: isWebBrowser(), isNative: !isWebBrowser() },
       sessionMode,
       identity,
+      // The device-wide shared credential slot, enabling the `shared-device-adopt`
+      // lane: a newly installed official app joins this device's existing session
+      // instead of falling back to signing a challenge with the Commons identity
+      // key. `null` on web, where each origin is its own device by design; the
+      // core lane is also skipped outright in `sessionMode: 'identity'`.
+      sharedDeviceCredential: createPlatformSharedDeviceCredentialStore() ?? undefined,
       overallDeadlineMs: COLD_BOOT_OVERALL_DEADLINE_MS,
       isOffline: () => offline,
       onStepDeadline: (stepId) => {

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -149,7 +149,7 @@ export const OxyRuntimeProvider: React.FC<OxyRuntimeProviderProps> = ({
   // provider mount.
   const authStoreRef = useRef<AuthStateStore | null>(null);
   if (!authStoreRef.current) {
-    authStoreRef.current = createPlatformAuthStateStore();
+    authStoreRef.current = createPlatformAuthStateStore({ sessionMode });
   }
   const authStore = authStoreRef.current;
 

--- a/packages/services/src/ui/session/__tests__/authStore.test.ts
+++ b/packages/services/src/ui/session/__tests__/authStore.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Which apps mirror their device credential into the device-wide shared slot.
+ *
+ * The mirror is what makes a later-installed official app able to JOIN this
+ * device's session instead of asking for the Commons identity key. It runs on
+ * native, in `'account'` mode only — the identity vault is excluded so that a
+ * background persist inside the vault can never change which session five other
+ * apps boot into.
+ */
+import type { AuthStateStore } from '@oxyhq/core';
+
+const CRED_STATE = { sessionId: 'sess-1', userId: 'user-1', deviceId: 'dev-1', deviceSecret: 'ds-1' };
+
+/** Track every credential handed to the shared slot by the store under test. */
+function makeSharedSpy() {
+  const published: { deviceId: string; deviceSecret: string }[] = [];
+  return {
+    published,
+    store: {
+      read: async () => ({ state: 'absent' as const }),
+      publish: async (credential: { deviceId: string; deviceSecret: string }) => {
+        published.push(credential);
+        return true;
+      },
+      clear: async () => undefined,
+    },
+  };
+}
+
+/**
+ * Build the platform store with the native seams stubbed. `jest.resetModules()`
+ * + `require` rather than `jest.isolateModules` for the same reason as
+ * `sharedDeviceCredentialStore.test.ts`: a factory registered inside an isolate
+ * leaked into the next one.
+ */
+function loadAuthStore(
+  os: 'ios' | 'android' | 'web',
+  sessionMode: 'account' | 'identity',
+  shared: ReturnType<typeof makeSharedSpy>,
+): AuthStateStore {
+  jest.resetModules();
+  jest.doMock('../sharedDeviceCredentialStore', () => ({
+    createPlatformSharedDeviceCredentialStore: () => (os === 'web' ? null : shared.store),
+  }));
+  const rn = require('react-native') as { Platform: { OS: string } };
+  rn.Platform.OS = os;
+  // `authStore` selects web-vs-native with `isReactNative()`, which reads
+  // `navigator.product` — NOT `Platform.OS`. Setting only the latter leaves it on
+  // the web branch, where nothing mirrors and every case passes for the wrong
+  // reason.
+  Object.defineProperty(globalThis.navigator, 'product', {
+    value: os === 'web' ? 'Gecko' : 'ReactNative',
+    configurable: true,
+  });
+  const mod = require('../authStore') as typeof import('../authStore');
+  return mod.createPlatformAuthStateStore({ sessionMode });
+}
+
+afterEach(() => {
+  jest.dontMock('../sharedDeviceCredentialStore');
+  Object.defineProperty(globalThis.navigator, 'product', { value: 'Gecko', configurable: true });
+  jest.resetModules();
+});
+
+describe('createPlatformAuthStateStore', () => {
+  test('an ordinary native app publishes its credential to the shared slot', async () => {
+    const shared = makeSharedSpy();
+    const store = loadAuthStore('android', 'account', shared);
+    await store.save(CRED_STATE);
+    expect(shared.published).toEqual([{ deviceId: 'dev-1', deviceSecret: 'ds-1' }]);
+  });
+
+  test('the identity vault does NOT publish', async () => {
+    // The vault's credential is a perfectly valid device credential, so this is a
+    // deliberate abstention, not an impossibility: publishing it would let every
+    // ordinary app on the device join the vault's session as a side effect of the
+    // vault persisting a token.
+    const shared = makeSharedSpy();
+    const store = loadAuthStore('android', 'identity', shared);
+    await store.save(CRED_STATE);
+    expect(shared.published).toEqual([]);
+  });
+
+  test('web has no shared slot to publish into', async () => {
+    const shared = makeSharedSpy();
+    const store = loadAuthStore('web', 'account', shared);
+    await store.save(CRED_STATE);
+    expect(shared.published).toEqual([]);
+  });
+});

--- a/packages/services/src/ui/session/__tests__/sharedDeviceCredentialStore.test.ts
+++ b/packages/services/src/ui/session/__tests__/sharedDeviceCredentialStore.test.ts
@@ -1,0 +1,289 @@
+/**
+ * The platform half of the shared DeviceSession credential.
+ *
+ * `@oxyhq/core` owns and tests the RULES; what is pinned here is the mapping from
+ * each platform's failure shapes onto them — and that mapping is where the
+ * dangerous mistake lives. `expo-secure-store` returns `null` for a missing item
+ * and THROWS when the keychain refuses; the Android broker answers with an
+ * explicit status. Collapsing either failure into "absent" is what would let a
+ * locked device look like one that never had a session.
+ */
+import type { SharedDeviceCredentialStore } from '@oxyhq/core';
+
+const CRED = { deviceId: 'dev-shared', deviceSecret: 'ds-shared' };
+const STORAGE_KEY = 'oxy_shared_device_session_v1';
+
+/** A minimal in-memory `expo-secure-store` that records the options it was given. */
+function makeSecureStoreMock() {
+  const items = new Map<string, string>();
+  const calls: { key: string; options?: Record<string, unknown> }[] = [];
+  let readError: Error | null = null;
+  let writeError: Error | null = null;
+  /** When set, `setItemAsync` resolves but nothing lands — the phantom-write case. */
+  let swallowWrites = false;
+  return {
+    items,
+    calls,
+    setReadError: (error: Error | null) => {
+      readError = error;
+    },
+    setWriteError: (error: Error | null) => {
+      writeError = error;
+    },
+    setSwallowWrites: (value: boolean) => {
+      swallowWrites = value;
+    },
+    module: {
+      WHEN_UNLOCKED_THIS_DEVICE_ONLY: 3,
+      getItemAsync: async (key: string, options?: Record<string, unknown>) => {
+        calls.push({ key, options });
+        if (readError) {
+          throw readError;
+        }
+        return items.get(key) ?? null;
+      },
+      setItemAsync: async (key: string, value: string, options?: Record<string, unknown>) => {
+        calls.push({ key, options });
+        if (writeError) {
+          throw writeError;
+        }
+        if (!swallowWrites) {
+          items.set(key, value);
+        }
+      },
+      deleteItemAsync: async (key: string, options?: Record<string, unknown>) => {
+        calls.push({ key, options });
+        items.delete(key);
+      },
+    },
+  };
+}
+
+type BrokerModule = {
+  read(): Promise<unknown>;
+  write(deviceId: string, deviceSecret: string): Promise<boolean>;
+  clear(): Promise<void>;
+};
+
+/**
+ * Load the module fresh, with `Platform.OS` set and both native seams mocked.
+ *
+ * Two things here are load-bearing and were each got wrong first:
+ *
+ *  - `jest.resetModules()` + `require`, NOT `jest.isolateModules`. The module
+ *    memoises its keychain and broker handles at module scope, so it must be
+ *    re-required per case — and with `isolateModules` a mock factory registered
+ *    in one block leaked into the next block's module, so a test's own mock was
+ *    silently ignored and its assertions read the PREVIOUS test's store.
+ *  - `Platform.OS` is set on the instance in the CURRENT registry. A reset hands
+ *    out a fresh `react-native` mock whose `OS` is back to its `'web'` default,
+ *    so mutating an instance captured earlier leaves the code under test on the
+ *    web branch and every platform assertion passes vacuously.
+ */
+function loadStore(
+  os: 'ios' | 'android' | 'web',
+  seams: { secureStore?: ReturnType<typeof makeSecureStoreMock>; broker?: BrokerModule | null } = {},
+): SharedDeviceCredentialStore | null {
+  jest.resetModules();
+  jest.doMock('expo-modules-core', () => ({
+    requireOptionalNativeModule: () => seams.broker ?? null,
+    requireNativeModule: () => {
+      throw new Error('not available');
+    },
+  }));
+  // NOT `{ virtual: true }`: a virtual mock is keyed to the directory of the
+  // file that declared it, so one declared here would be invisible to the module
+  // under test two directories up — it would silently keep resolving
+  // `unsupported`. `expo-secure-store` is installed in the workspace, so the
+  // ordinary mock registers against its real resolved path. With no mock given,
+  // model the module being ABSENT.
+  const secureStoreModule = seams.secureStore?.module;
+  jest.doMock('expo-secure-store', () => {
+    if (!secureStoreModule) {
+      throw new Error("Cannot find module 'expo-secure-store'");
+    }
+    return secureStoreModule;
+  });
+  const rn = require('react-native') as { Platform: { OS: string } };
+  rn.Platform.OS = os;
+  const mod = require('../sharedDeviceCredentialStore') as typeof import('../sharedDeviceCredentialStore');
+  return mod.createPlatformSharedDeviceCredentialStore();
+}
+
+afterEach(() => {
+  jest.dontMock('expo-modules-core');
+  jest.dontMock('expo-secure-store');
+  jest.resetModules();
+});
+
+describe('createPlatformSharedDeviceCredentialStore', () => {
+  test('web has no shared slot at all', () => {
+    // Each web origin is its own device by design; there is nothing to join.
+    expect(loadStore('web')).toBeNull();
+    // Positive control: `null` must mean "web", not "the harness never reached
+    // the platform branch" — the failure mode this whole harness had once.
+    expect(loadStore('android', { broker: null })).not.toBeNull();
+    expect(loadStore('ios')).not.toBeNull();
+  });
+
+  test('iOS uses the keychain, not the Android broker', async () => {
+    // The branch is on the platform because `expo-secure-store` LOADS on Android
+    // too — it would just ignore the access group and read a package-private
+    // item, which is indistinguishable from an empty shared slot.
+    const secureStore = makeSecureStoreMock();
+    const broker: BrokerModule = {
+      read: jest.fn(async () => ({ status: 'present', ...CRED })),
+      write: jest.fn(async () => true),
+      clear: jest.fn(async () => undefined),
+    };
+    const store = loadStore('ios', { secureStore, broker });
+    await store?.read();
+    expect(broker.read).not.toHaveBeenCalled();
+    expect(secureStore.calls.length).toBeGreaterThan(0);
+  });
+
+  test('Android uses the broker, not the keychain', async () => {
+    const secureStore = makeSecureStoreMock();
+    const broker: BrokerModule = {
+      read: jest.fn(async () => ({ status: 'absent' })),
+      write: jest.fn(async () => true),
+      clear: jest.fn(async () => undefined),
+    };
+    const store = loadStore('android', { secureStore, broker });
+    await expect(store?.read()).resolves.toEqual({ state: 'absent' });
+    expect(broker.read).toHaveBeenCalled();
+    expect(secureStore.calls).toHaveLength(0);
+  });
+});
+
+describe('iOS keychain-group slot', () => {
+  test('a missing item is absent; a THROWN read is unavailable', async () => {
+    const secureStore = makeSecureStoreMock();
+    const store = loadStore('ios', { secureStore });
+
+    await expect(store?.read()).resolves.toEqual({ state: 'absent' });
+
+    secureStore.setReadError(new Error('User interaction is not allowed'));
+    const locked = await store?.read();
+    // The pair that must never be confused. `absent` authorises seeding the slot.
+    expect(locked?.state).toBe('unavailable');
+  });
+
+  test('an unparseable item is unavailable, never absent', async () => {
+    const secureStore = makeSecureStoreMock();
+    secureStore.items.set(STORAGE_KEY, 'not-json-at-all');
+    const store = loadStore('ios', { secureStore });
+    // Something IS stored. Reporting absent would authorise overwriting whatever
+    // a newer build put there.
+    expect((await store?.read())?.state).toBe('unavailable');
+  });
+
+  test('reads and writes carry the dedicated service AND the access group', async () => {
+    const secureStore = makeSecureStoreMock();
+    const store = loadStore('ios', { secureStore });
+    await store?.publish(CRED);
+
+    // Without `keychainAccessGroup` the item is package-private and no sibling
+    // app can ever join. Without the dedicated `keychainService` it shares the
+    // legacy shared-IDENTITY namespace inside the group — the exact conflation
+    // this phase exists to end.
+    for (const call of secureStore.calls) {
+      expect(call.options).toMatchObject({
+        keychainService: 'oxy_device_session',
+        keychainAccessGroup: 'group.so.oxy.shared',
+      });
+    }
+    expect(secureStore.calls.length).toBeGreaterThan(0);
+  });
+
+  test('the item is written device-only so it never rides an OS backup to a new handset', async () => {
+    const secureStore = makeSecureStoreMock();
+    const store = loadStore('ios', { secureStore });
+    await store?.publish(CRED);
+    const write = secureStore.calls.find((c) => c.options?.keychainAccessible !== undefined);
+    expect(write?.options?.keychainAccessible).toBe(secureStore.module.WHEN_UNLOCKED_THIS_DEVICE_ONLY);
+  });
+
+  test('a publish round-trips and reads back as present', async () => {
+    const secureStore = makeSecureStoreMock();
+    const store = loadStore('ios', { secureStore });
+    await expect(store?.publish(CRED)).resolves.toBe(true);
+    await expect(store?.read()).resolves.toEqual({ state: 'present', credential: CRED });
+  });
+
+  test('a write that silently does not land reports false', async () => {
+    // A keychain write can resolve without the item landing under the access
+    // group (a missing entitlement is the usual cause). A phantom credential
+    // would send a fresh install into a mint that can never succeed.
+    const secureStore = makeSecureStoreMock();
+    secureStore.setSwallowWrites(true);
+    const store = loadStore('ios', { secureStore });
+    await expect(store?.publish(CRED)).resolves.toBe(false);
+  });
+
+  test('a throwing write reports false rather than propagating', async () => {
+    const secureStore = makeSecureStoreMock();
+    secureStore.setWriteError(new Error('keychain error -34018'));
+    const store = loadStore('ios', { secureStore });
+    await expect(store?.publish(CRED)).resolves.toBe(false);
+  });
+
+  test('the slot is unsupported when expo-secure-store is not installed', async () => {
+    const store = loadStore('ios');
+    // No `expo-secure-store` mock registered → the dynamic import rejects.
+    expect((await store?.read())?.state).toBe('unsupported');
+  });
+});
+
+describe('Android broker slot', () => {
+  test('narrows a present payload', async () => {
+    const store = loadStore('android', {
+      broker: { read: async () => ({ status: 'present', ...CRED }), write: async () => true, clear: async () => undefined },
+    });
+    await expect(store?.read()).resolves.toEqual({ state: 'present', credential: CRED });
+  });
+
+  test('an explicit unavailable status stays unavailable', async () => {
+    const store = loadStore('android', {
+      broker: {
+        read: async () => ({ status: 'unavailable', reason: 'GeneralSecurityException' }),
+        write: async () => true,
+        clear: async () => undefined,
+      },
+    });
+    expect((await store?.read())?.state).toBe('unavailable');
+  });
+
+  test('a THROWN broker call is unavailable, never absent', async () => {
+    const store = loadStore('android', {
+      broker: {
+        read: async () => {
+          throw new Error('binder transaction failed');
+        },
+        write: async () => true,
+        clear: async () => undefined,
+      },
+    });
+    expect((await store?.read())?.state).toBe('unavailable');
+  });
+
+  test('an unrecognised payload from an older sibling is unavailable, never absent', async () => {
+    const store = loadStore('android', {
+      broker: { read: async () => ({ ok: true }), write: async () => true, clear: async () => undefined },
+    });
+    expect((await store?.read())?.state).toBe('unavailable');
+  });
+
+  test('the slot is unsupported when the native module is not linked', async () => {
+    const store = loadStore('android', { broker: null });
+    expect((await store?.read())?.state).toBe('unsupported');
+    await expect(store?.publish(CRED)).resolves.toBe(false);
+  });
+
+  test('publish forwards the broker’s own read-back verdict', async () => {
+    const unverified = loadStore('android', {
+      broker: { read: async () => ({ status: 'absent' }), write: async () => false, clear: async () => undefined },
+    });
+    await expect(unverified?.publish(CRED)).resolves.toBe(false);
+  });
+});

--- a/packages/services/src/ui/session/authStore.ts
+++ b/packages/services/src/ui/session/authStore.ts
@@ -11,15 +11,41 @@
  *  - web  → `createWebAuthStateStore()` (localStorage, in-memory fallback).
  *  - native → `createNativeAuthStateStore(secureKV)` for the SESSION blob over
  *    the shared `createNativeSecureKeyValueStorage()` adapter
- *    (`expo-secure-store`, AsyncStorage fallback).
+ *    (`expo-secure-store`, AsyncStorage fallback), WRAPPED so every credential
+ *    it persists is also mirrored into the device-wide shared slot.
+ *
+ * The native wrapper is how several official apps end up on ONE `DeviceSession`
+ * (and therefore one active context): whichever app proves a credential publishes
+ * it, and a later-installed sibling adopts it during cold boot instead of asking
+ * for the Commons identity key. The mirror is additive — it can neither change
+ * nor fail the app's own durable write.
  */
 import {
   createWebAuthStateStore,
   createNativeAuthStateStore,
+  createSharedMirroringAuthStateStore,
   type AuthStateStore,
+  type SessionMode,
 } from '@oxyhq/core';
 import { isReactNative } from '../utils/storageHelpers';
 import { createNativeSecureKeyValueStorage } from './nativeSecureStorage';
+import { createPlatformSharedDeviceCredentialStore } from './sharedDeviceCredentialStore';
+
+export interface PlatformAuthStateStoreOptions {
+  /**
+   * Who owns the session this provider resolves. Only `'account'` mirrors into
+   * the device-wide shared slot.
+   *
+   * `'identity'` (the vault) is deliberately excluded, which keeps its storage
+   * behaviour byte-for-byte what it is today. The vault's credential is a
+   * perfectly valid device credential, so publishing it would arguably be
+   * correct — but it would also let every ordinary app on the device join the
+   * vault's device session as a side effect of the vault persisting a token, and
+   * "a background write changes which session five other apps boot into" is not
+   * a decision a storage seam gets to make.
+   */
+  sessionMode?: SessionMode;
+}
 
 /**
  * Build the platform {@link AuthStateStore} for this runtime.
@@ -28,10 +54,17 @@ import { createNativeSecureKeyValueStorage } from './nativeSecureStorage';
  * token) per-app in SecureStore; the SDK re-mints the access token from the
  * device credential on the next cold boot.
  */
-export function createPlatformAuthStateStore(): AuthStateStore {
+export function createPlatformAuthStateStore(
+  options: PlatformAuthStateStoreOptions = {},
+): AuthStateStore {
   if (!isReactNative()) {
     return createWebAuthStateStore();
   }
 
-  return createNativeAuthStateStore(createNativeSecureKeyValueStorage());
+  const local = createNativeAuthStateStore(createNativeSecureKeyValueStorage());
+  if (options.sessionMode === 'identity') {
+    return local;
+  }
+  const shared = createPlatformSharedDeviceCredentialStore();
+  return shared ? createSharedMirroringAuthStateStore({ local, shared }) : local;
 }

--- a/packages/services/src/ui/session/sharedDeviceCredentialStore.ts
+++ b/packages/services/src/ui/session/sharedDeviceCredentialStore.ts
@@ -1,0 +1,318 @@
+/**
+ * The platform half of the shared native DeviceSession credential.
+ *
+ * `@oxyhq/core` owns the rules (`sharedDeviceCredential.ts`: when to adopt, when
+ * to publish, and above all that an unreadable slot is never an empty one). This
+ * module owns only where the bytes live, which is genuinely different per
+ * platform:
+ *
+ *  - **iOS** — one `expo-secure-store` item in the approved Keychain Access Group
+ *    `group.so.oxy.shared`, under its OWN `keychainService`
+ *    ({@link IOS_DEVICE_SESSION_KEYCHAIN_SERVICE}). Every identity slot uses a
+ *    different service (`oxy_identity`, `oxy_identity_backup`,
+ *    `oxy_identity_mnemonic`) and the legacy cross-app identity keypair uses the
+ *    same group with NO service at all — so this item cannot alias any of them.
+ *    That separation is the point of the whole phase: the group-shared identity
+ *    key and the group-shared device-session credential are different secrets
+ *    with different blast radii and must not be conflated.
+ *  - **Android** — the signature-protected `OxyDeviceSession` broker (its own
+ *    EncryptedSharedPreferences file, its own ContentProvider, its own
+ *    `signature`-level permission). It carries a session credential; it can NOT
+ *    reach the identity keypair, which lives in a different file behind a
+ *    different provider.
+ *  - **web / anything else** — no shared slot. Each origin is its own device by
+ *    design, so the factory returns `null` and the cold boot simply omits the
+ *    lane.
+ *
+ * ## What is written here, and what is not
+ *
+ * Only `{deviceId, deviceSecret}`. No access token, no account id, no user id,
+ * and never any identity key material.
+ *
+ * ## Accessibility
+ *
+ * `WHEN_UNLOCKED_THIS_DEVICE_ONLY`: a device credential must not travel to
+ * another handset in an iCloud/encrypted backup restore — the restored device is
+ * a different device and has to establish its own session. It also keeps the item
+ * out of reach while the phone is locked, which is why a read can legitimately
+ * fail and why the `unavailable` verdict exists at all.
+ */
+import { Platform } from 'react-native';
+import { requireOptionalNativeModule } from 'expo-modules-core';
+import {
+  normalizeSharedDeviceSessionRead,
+  type SharedDeviceCredential,
+  type SharedDeviceCredentialRead,
+  type SharedDeviceCredentialStore,
+} from '@oxyhq/core';
+
+/**
+ * The iOS Keychain Access Group every official Oxy app declares in its
+ * entitlements. Shared with the identity slots — the group is the app-group
+ * boundary, not the secret's identity.
+ */
+export const IOS_KEYCHAIN_ACCESS_GROUP = 'group.so.oxy.shared';
+
+/**
+ * The iOS `keychainService` for the DEVICE SESSION credential. Deliberately
+ * distinct from every identity and recovery service; do not reuse one of those
+ * here, and do not drop it (an item written with no service shares the legacy
+ * identity slot's namespace inside the group).
+ */
+export const IOS_DEVICE_SESSION_KEYCHAIN_SERVICE = 'oxy_device_session';
+
+/** The single key holding the JSON-encoded `{deviceId, deviceSecret}` pair. */
+export const SHARED_DEVICE_SESSION_STORAGE_KEY = 'oxy_shared_device_session_v1';
+
+// Variable indirection so Metro's static analyzer never traces expo-secure-store
+// into the web bundle; the module is native-only and optional.
+const SECURE_STORE_MODULE = 'expo-secure-store';
+
+/**
+ * The subset of `expo-secure-store` this module needs. Unlike the adapter in
+ * `nativeSecureStorage.ts` it must pass OPTIONS — the access group and the
+ * dedicated service are the entire mechanism here, so an options-less wrapper
+ * would silently write a package-private item that no sibling app can see.
+ */
+interface KeychainGroupStore {
+  getItemAsync(key: string, options?: object): Promise<string | null>;
+  setItemAsync(key: string, value: string, options?: object): Promise<void>;
+  deleteItemAsync(key: string, options?: object): Promise<void>;
+  readonly WHEN_UNLOCKED_THIS_DEVICE_ONLY: number;
+}
+
+let keychainStorePromise: Promise<KeychainGroupStore | null> | null = null;
+
+function loadKeychainGroupStore(): Promise<KeychainGroupStore | null> {
+  if (!keychainStorePromise) {
+    const moduleName = SECURE_STORE_MODULE;
+    keychainStorePromise = import(moduleName)
+      .then((mod: Partial<KeychainGroupStore>) => {
+        if (
+          typeof mod.getItemAsync === 'function' &&
+          typeof mod.setItemAsync === 'function' &&
+          typeof mod.deleteItemAsync === 'function' &&
+          typeof mod.WHEN_UNLOCKED_THIS_DEVICE_ONLY === 'number'
+        ) {
+          return {
+            getItemAsync: mod.getItemAsync.bind(mod),
+            setItemAsync: mod.setItemAsync.bind(mod),
+            deleteItemAsync: mod.deleteItemAsync.bind(mod),
+            WHEN_UNLOCKED_THIS_DEVICE_ONLY: mod.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+          } satisfies KeychainGroupStore;
+        }
+        return null;
+      })
+      .catch(() => null);
+  }
+  return keychainStorePromise;
+}
+
+/** Parse the stored JSON into a credential, or `null` for anything malformed. */
+function parseStoredCredential(raw: string | null): SharedDeviceCredential | null {
+  if (!raw) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return null;
+  }
+  const candidate = parsed as Record<string, unknown>;
+  if (
+    typeof candidate.deviceId !== 'string' ||
+    candidate.deviceId.length === 0 ||
+    typeof candidate.deviceSecret !== 'string' ||
+    candidate.deviceSecret.length === 0
+  ) {
+    return null;
+  }
+  return { deviceId: candidate.deviceId, deviceSecret: candidate.deviceSecret };
+}
+
+/**
+ * The iOS store: one keychain item in the shared access group.
+ *
+ * A THROWN read is `unavailable`, a `null` read is `absent`. That mapping is the
+ * whole safety contract — `expo-secure-store` returns `null` for a genuinely
+ * missing item and throws when the keychain itself refuses, and collapsing the
+ * two is what would let a locked phone look like a device that never had a
+ * session.
+ */
+function createKeychainGroupCredentialStore(): SharedDeviceCredentialStore {
+  const readOptions = {
+    keychainService: IOS_DEVICE_SESSION_KEYCHAIN_SERVICE,
+    keychainAccessGroup: IOS_KEYCHAIN_ACCESS_GROUP,
+  };
+
+  return {
+    read: async (): Promise<SharedDeviceCredentialRead> => {
+      const store = await loadKeychainGroupStore();
+      if (!store) {
+        return { state: 'unsupported' };
+      }
+      let raw: string | null;
+      try {
+        raw = await store.getItemAsync(SHARED_DEVICE_SESSION_STORAGE_KEY, readOptions);
+      } catch (error) {
+        return { state: 'unavailable', cause: error };
+      }
+      if (raw === null) {
+        return { state: 'absent' };
+      }
+      const credential = parseStoredCredential(raw);
+      if (!credential) {
+        // Something IS stored and we cannot read it. Reporting `absent` would
+        // authorise overwriting whatever a newer build put there.
+        return {
+          state: 'unavailable',
+          cause: new Error('shared device session item is present but not parseable'),
+        };
+      }
+      return { state: 'present', credential };
+    },
+
+    publish: async (credential): Promise<boolean> => {
+      const store = await loadKeychainGroupStore();
+      if (!store) {
+        return false;
+      }
+      const value = JSON.stringify(credential);
+      try {
+        await store.setItemAsync(SHARED_DEVICE_SESSION_STORAGE_KEY, value, {
+          ...readOptions,
+          keychainAccessible: store.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+        });
+        // Read-back verify. A keychain write can resolve without the item having
+        // landed under the access group (a missing entitlement is the usual
+        // cause), and a phantom credential would send a fresh install into a mint
+        // that can never succeed.
+        return (await store.getItemAsync(SHARED_DEVICE_SESSION_STORAGE_KEY, readOptions)) === value;
+      } catch {
+        return false;
+      }
+    },
+
+    clear: async (): Promise<void> => {
+      const store = await loadKeychainGroupStore();
+      if (!store) {
+        return;
+      }
+      try {
+        await store.deleteItemAsync(SHARED_DEVICE_SESSION_STORAGE_KEY, readOptions);
+      } catch {
+        // Best-effort: the slot is a join point, not a source of truth.
+      }
+    },
+  };
+}
+
+/**
+ * The Android broker's JS surface. `read` returns an UNTRUSTED payload that
+ * {@link normalizeSharedDeviceSessionRead} narrows; `write` reports whether the
+ * native read-back confirmed the bytes.
+ */
+interface OxyDeviceSessionNativeModule {
+  read(): Promise<unknown>;
+  write(deviceId: string, deviceSecret: string): Promise<boolean>;
+  clear(): Promise<void>;
+}
+
+let brokerModule: OxyDeviceSessionNativeModule | null | undefined;
+
+/**
+ * Resolve the `OxyDeviceSession` broker, or `null` when it is not autolinked.
+ *
+ * `requireOptionalNativeModule` (a static import Metro always resolves) rather
+ * than a dynamic `import(moduleName)`: the latter compiles to `require(variable)`
+ * in the CJS build, which Metro cannot resolve inside a consuming app — it
+ * silently returns `null` there, which is exactly how the cross-app identity
+ * bridge broke once. Same reasoning as `backgroundSession.ts` next door.
+ */
+function loadBrokerModule(): OxyDeviceSessionNativeModule | null {
+  if (brokerModule === undefined) {
+    const native = requireOptionalNativeModule<Partial<OxyDeviceSessionNativeModule>>('OxyDeviceSession');
+    brokerModule =
+      native && typeof native.read === 'function' && typeof native.write === 'function' && typeof native.clear === 'function'
+        ? {
+            read: native.read.bind(native),
+            write: native.write.bind(native),
+            clear: native.clear.bind(native),
+          }
+        : null;
+  }
+  return brokerModule;
+}
+
+/**
+ * The Android store: the signature-protected `OxyDeviceSession` broker.
+ *
+ * The broker already answers with an explicit status, so the only work here is
+ * narrowing an UNTRUSTED payload — `normalizeSharedDeviceSessionRead` resolves
+ * anything it does not recognise to `unavailable`, never `absent`.
+ */
+function createBrokerCredentialStore(): SharedDeviceCredentialStore {
+  return {
+    read: async (): Promise<SharedDeviceCredentialRead> => {
+      const broker = loadBrokerModule();
+      if (!broker) {
+        return { state: 'unsupported' };
+      }
+      try {
+        return normalizeSharedDeviceSessionRead(await broker.read());
+      } catch (error) {
+        return { state: 'unavailable', cause: error };
+      }
+    },
+
+    publish: async (credential): Promise<boolean> => {
+      const broker = loadBrokerModule();
+      if (!broker) {
+        return false;
+      }
+      try {
+        // The broker read-back-verifies natively and returns the verdict.
+        return await broker.write(credential.deviceId, credential.deviceSecret);
+      } catch {
+        return false;
+      }
+    },
+
+    clear: async (): Promise<void> => {
+      const broker = loadBrokerModule();
+      if (!broker) {
+        return;
+      }
+      try {
+        await broker.clear();
+      } catch {
+        // Best-effort — see the iOS store.
+      }
+    },
+  };
+}
+
+/**
+ * The shared DeviceSession credential slot for this runtime, or `null` when
+ * there is none.
+ *
+ * The branch is on the PLATFORM, not on which module happens to load, because
+ * `expo-secure-store` loads perfectly well on Android — it would just quietly
+ * ignore `keychainAccessGroup` and read a package-private item, which looks
+ * exactly like an empty shared slot. This is the same iOS-vs-Android split
+ * `KeyManager` makes for the shared identity, for the same reason.
+ *
+ * Any other native platform gets the broker, which answers `unsupported` when
+ * the module is not linked — so the lane is simply off, which is the safe
+ * direction.
+ */
+export function createPlatformSharedDeviceCredentialStore(): SharedDeviceCredentialStore | null {
+  if (Platform.OS === 'web') {
+    return null;
+  }
+  return Platform.OS === 'ios' ? createKeychainGroupCredentialStore() : createBrokerCredentialStore();
+}


### PR DESCRIPTION
Phase 4 of #937 — a shared native DeviceSession credential, separate from the Commons private key.

# ⚠️ UNVERIFIED ON ANY DEVICE

No adb, no emulator, no install. Everything below is unit-level plus source-gating. **Do not present this as verified, and do not install any build of it on a device holding a real identity.** The hazard is UID-scoped (`so.oxy.shared`), so it covers Commons, Mention, Accounts, Allo, Homiio and any same-signer `.dev` variant — and Commons is self-custody, so a destroyed slot with no written 12-word phrase is permanent. Verification is emulator or a disposable identity; real delivery is store/EAS only.

## The finding that removed half the work

**No server change was needed.** `POST /session/device/token` does not rotate — it echoes the presented secret back as `nextDeviceSecret` (`sessionDevice.ts:127-130`), deliberately, so several first-party apps sharing one DeviceSession can refresh concurrently. N native apps holding one `{deviceId, deviceSecret}` is therefore an already-supported server state: they land on one DeviceSession and so on one `activeContextId`. **`packages/api` is untouched.**

## Design

**iOS** — one expo-secure-store item under its own `keychainService: 'oxy_device_session'` inside `group.so.oxy.shared`, `WHEN_UNLOCKED_THIS_DEVICE_ONLY`. Distinct from `oxy_identity`, `oxy_identity_backup`, `oxy_identity_mnemonic`, and from the legacy `oxy_shared_identity_*` keys (same group, no service). The whole point of ADR-era slot discipline: a new secret class gets its own service, never the default, because anything without one shares a single AndroidKeyStore key and dies with it.

**Android** — a new `OxyDeviceSession` module: its own EncryptedSharedPreferences file (`RebuildFileOnly`, so it cannot reach the master-key reset), its own signature-checked ContentProvider, its own `signature`-level permission, read-only across the process boundary. **It never touches the keypair.**

**Writes mirror, reads adopt explicitly.** The native AuthStateStore is wrapped so every lane that persists a proven credential publishes it — one seam, so no lane can forget. Adoption is a *visible* cold-boot step, `shared-device-adopt`, sitting between `device-secret-mint` and `shared-key-signin`, because it changes who the app is signed in as and that should never be invisible.

Adopt only when the slot is `present` **and** this app has no credential. Publish only into an `absent` slot or over the same `deviceId`. **Never write on a read that failed** — the read is four states, not a nullable. `shared-key-signin` stays last as the recovery lane, and its own persist seeds the slot, so the first boot that needs it is the last one that does. The identity vault neither adopts nor publishes.

## Mutations: 40 applied, 40 killed

Including the one that matters most — making `unavailable` fall through to `absent`. It is guarded in four places and every variant went red. That is the test standing between a user and a destroyed identity.

**One of the gates was itself wrong**: the per-arm status scan ran the last arm to end-of-file and swallowed the companion object's constants, so it failed against the real source. Fixed in the second commit, three provider mutations re-run and re-killed.

## Verification

core 117/1637 → **119/1686**; services 76/688 → **79/724**. Baselines measured at the actual branch point rather than taken from me — I had quoted post-#964 numbers. tsc clean in both; lint clean on every touched file.

## #937's Native test list — what is and is not covered

**Covered, unit level:** ordinary apps do not need the Commons key; per-app legacy migration (nothing is deleted, so there is no delete-before-verify window at all); upgrade order cannot sign anyone out; keystore-unavailable is not read as no-session; OS-backup non-migration (accessibility constant asserted).

**NOT verified:** iOS access-group sharing between two real apps; Android same-signature sharing; an incorrectly-signed app being refused (source-gated only — Kotlin is not compiled in CI); app reinstall and a real keystore reset; multiple principals across restarts.

## Limitations, stated

1. **Two apps that each already own a *different* device session stay separate** until one loses its credential. Converging them needs a signout or a server-side device merge — the honest fix, and out of scope. A real gap in "one device, one session".
2. Android hosting is restricted to `so.oxy.shared` UID members (they share one file, so the sweep is deterministic). Same-signature apps outside the UID may join but must not host.
3. The provider authority list is hand-maintained in three places; a gate fails on drift, with a vacuity floor.
4. Only `accounts` and `commons` are wired. Mention/Allo/Homiio are other repos and need the reader plugin.
5. **No docs written** — `SESSION-ARCHITECTURE.md` and `AUTHENTICATION.md` still describe `shared-key-signin` as the only native cross-app lane.

Refs #937