### PR TITLE
chore(release): contracts 0.26.0, core 21.0.0, services 29.0.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -408,7 +408,7 @@
     },
     "packages/contracts": {
       "name": "@oxyhq/contracts",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "dependencies": {
         "zod": "^3.25.64",
       },
@@ -421,7 +421,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "20.1.0",
+      "version": "21.0.0",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/hashes": "^1.8.0",
@@ -613,7 +613,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "28.0.0",
+      "version": "29.0.0",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "@simplewebauthn/browser": "^13.3.0",
@@ -667,7 +667,7 @@
       "peerDependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@oxyhq/bloom": ">=0.59.0",
-        "@oxyhq/core": "^20.0.0",
+        "@oxyhq/core": "^21.0.0",
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@react-native-community/netinfo": ">=11.4.1",
         "@tanstack/query-async-storage-persister": "catalog:",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oxyhq/contracts",
-  "version": "0.25.0",
-  "description": "OxyHQ API contracts — single source of truth for request/response Zod schemas and inferred types, shared by the backend and the client SDKs",
+  "version": "0.26.0",
+  "description": "OxyHQ API contracts \u2014 single source of truth for request/response Zod schemas and inferred types, shared by the backend and the client SDKs",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "20.1.0",
+  "version": "21.0.0",
   "description": "OxyHQ SDK Foundation \u2014 API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "28.0.0",
+  "version": "29.0.0",
   "description": "OxyHQ Expo/React Native SDK \u2014 UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -190,7 +190,7 @@
   "peerDependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@oxyhq/bloom": ">=0.59.0",
-    "@oxyhq/core": "^20.0.0",
+    "@oxyhq/core": "^21.0.0",
     "@react-native-async-storage/async-storage": "^2.0.0",
     "@react-native-community/netinfo": ">=11.4.1",
     "@tanstack/query-async-storage-persister": "catalog:",


### PR DESCRIPTION
Version bumps for #937. No behaviour change — manifests and `bun.lock` only.

## Why two majors

#937 removed **published exports** from two packages. The change volume suggests a minor; the public surface says otherwise, and this repo has already paid for that mistake once — `core@13.2.0` shipped a runtime-breaking change under a minor, had to be deprecated, and was republished as `14.0.0`. The rule written down afterwards: a publicly exported symbol is public API even when you can prove nobody in the org imports it, because semver exists for the consumers you cannot enumerate.

**`@oxyhq/core` 20.1.0 → 21.0.0** — drops `SwitchableAccount`, `projectSwitchableAccounts`, `switchableAccountIds`, `AccountDialogSnapshot.accounts` / `.activeAccountId` / `.switchingAccountId`, `switchTo`, and two constructor options. Also changes `exchangeOAuthCode`'s `deviceId` from `string` to `string | undefined` — a compile error for `const d: string = result.deviceId`, and deliberately so: the method used to either throw or return one, and it can now resolve without one.

**`@oxyhq/services` 28.0.0 → 29.0.0** — deletes `useAccountStore` (write-only, zero readers repo-wide) and renames `useSwitchableAccounts` to `useDeviceSwitcher`. It also gains `deviceCredentialStorage` on `OxyProvider`, which alone would be a minor; the major absorbs it.

**`@oxyhq/contracts` 0.25.0 → 0.26.0** — additive only: the device directory, the OAuth hub schemas, and `color` on the directory profile.

## Two details that are easy to miss

**The peer range moves too.** `services`' `peerDependencies["@oxyhq/core"]` goes `^20.0.0` → `^21.0.0`. Left at `^20` it would resolve a core that does not contain the exports this version of services is written against — exactly the failure the range exists to prevent.

**Publishing order is contracts → core → services.** Core imports the new contracts symbols, so a core published against a contracts that is not yet on the registry leaves consumers with a caret pointing at nothing.

## Verification

`bun.lock` regenerated and committed in the same commit as the manifests. `scripts/check-lockfile-sync.mjs`: *"bun.lock is in sync with every package.json."*

Merged `main` was green across all four packages immediately before these bumps — core **1686**, services **732**, contracts **266**, auth **200 pass / 0 fail**.

Live npm was checked before choosing the numbers: `core@20.1.0`, `services@28.0.0`, `contracts@0.25.0` — repo and registry were in sync, so nothing has been advanced out of band by another release process.

Refs #937